### PR TITLE
Update ApiClient.cs

### DIFF
--- a/src/FingerprintPro.ServerSdk/Client/ApiClient.cs
+++ b/src/FingerprintPro.ServerSdk/Client/ApiClient.cs
@@ -31,18 +31,7 @@ namespace FingerprintPro.ServerSdk.Client
         public ApiClient(Configuration config)
         {
             Configuration = config;
-
-            Client = config.HttpClient ?? new HttpClient();
-
-            if (Client.BaseAddress == null)
-            {
-                Client.BaseAddress = new Uri(Configuration.BasePath);
-            }
-
-            foreach (var header in config.DefaultHeader)
-            {
-                Client.DefaultRequestHeaders.Add(header.Key, header.Value);
-            }
+            Client = config.HttpClient ?? new HttpClient() { BaseAddress = new Uri(Configuration.BasePath)};
         }
 
         /// <summary>
@@ -88,6 +77,11 @@ namespace FingerprintPro.ServerSdk.Client
             if (!string.IsNullOrEmpty(apiKey))
             {
                 request.Headers.TryAddWithoutValidation("Auth-API-Key", apiKey);
+            }
+
+            foreach (var header in config.DefaultHeader)
+            {
+                request.Headers.TryAddWithoutValidation(header.Key, header.Value);
             }
 
             return request;


### PR DESCRIPTION
The reason I asked for the ability to pass in HttpClient is so a single reusable instance with a logging handler could be passed in.

As such, the HttpClient base address should not be set if the client is passed in. This will throw an InvalidOperationException if the client has been used before.

Additionally, the default headers should be set at the request object as they will be different for each instantiation of FingerprintApi -- even though the HttpClient will be the same.

I know you generally don't accept community pull requests but I'd appreciate if you'd consider this.