### PR TITLE
Update ApiClient.cs

### DIFF
--- a/src/FingerprintPro.ServerSdk/Client/ApiClient.cs
+++ b/src/FingerprintPro.ServerSdk/Client/ApiClient.cs
@@ -94,7 +94,7 @@ namespace FingerprintPro.ServerSdk.Client
 
         private UriBuilder GetRequestPath(OperationDefinition definition, params string[] args)
         {
-            var uri = new UriBuilder(Client.BaseAddress!)
+            var uri = new UriBuilder(Configuration.BasePath!)
             {
                 Path = definition.GetPath(args)
             };


### PR DESCRIPTION
To support passing in HttpClient instances used for other purposes besides FP, a null BaseAddress is needed on the HttpClient.

However, if a client with a null BaseAddress is passed in, GetRequestPath will throw an exception trying to construct the request URL.

This change sets the request URL base (i.e. the region-specific FP API domain) from Configuration object rather than the HttpClient's BaseAddress. These are of course the same values per :37 in cases where the HttpClient instance is not passed in.

(If someone passes in an HttpClient instance with a different non-null BaseAddress than the FP one on the Configuration object, then they'll rightfully get an exception when the request is executed).