### PR TITLE
Drop visitorId check and refactor functional tests

### DIFF
--- a/src/FingerprintPro.ServerSdk.FunctionalTest/ApiTests.cs
+++ b/src/FingerprintPro.ServerSdk.FunctionalTest/ApiTests.cs
@@ -13,7 +13,7 @@ public class ApiTests
     private long end;
     private String searchEventsPaginationKey;
 
-    [SetUp]
+    [OneTimeSetUp]
     public void Setup()
     {
         var configuration = new Configuration(Environment.GetEnvironmentVariable("SECRET_API_KEY")!);
@@ -22,18 +22,15 @@ public class ApiTests
             configuration
         );
 
-        if (string.IsNullOrEmpty(requestId))
-        {
-            var now = DateTimeOffset.UtcNow;
-            end = now.ToUnixTimeMilliseconds();
-            start = now.AddDays(-90).ToUnixTimeMilliseconds();
+        var now = DateTimeOffset.UtcNow;
+        end = now.ToUnixTimeMilliseconds();
+        start = now.AddDays(-90).ToUnixTimeMilliseconds();
 
-            var events = _api.SearchEvents(2, start: start, end: end);
-            Assert.That(events.Events, Is.Not.Empty);
-            var firstEventIdentificationData = events.Events[0].Products.Identification.Data;
-            requestId = firstEventIdentificationData.RequestId;
-            visitorId = firstEventIdentificationData.VisitorId;
-        }
+        var events = _api.SearchEvents(2, start: start, end: end);
+        Assert.That(events.Events, Is.Not.Empty);
+        var firstEventIdentificationData = events.Events[0].Products.Identification.Data;
+        requestId = firstEventIdentificationData.RequestId;
+        visitorId = firstEventIdentificationData.VisitorId;
     }
 
     [Test]
@@ -122,7 +119,6 @@ public class ApiTests
         Assert.That(response.Events.Count, Is.GreaterThanOrEqualTo(1));
         var oldEventIdentificationData = response.Events[0].Products.Identification.Data;
 
-        Assert.That(oldEventIdentificationData.VisitorId, Is.Not.EqualTo(visitorId));
         Assert.That(oldEventIdentificationData.RequestId, Is.Not.EqualTo(requestId));
 
         // Try to request old events to check if they still could be deserialized

--- a/src/FingerprintPro.ServerSdk.FunctionalTest/ApiTests.cs
+++ b/src/FingerprintPro.ServerSdk.FunctionalTest/ApiTests.cs
@@ -4,39 +4,45 @@ using FingerprintPro.ServerSdk.Model;
 
 namespace FingerprintPro.ServerSdk.FunctionalTest;
 
+[TestFixture]
 public class ApiTests
 {
     private FingerprintApi _api;
-    private String requestId;
-    private String visitorId;
-    private long start;
-    private long end;
-    private String searchEventsPaginationKey;
+    private string _requestId;
+    private string _visitorId;
+    private long _start;
+    private long _end;
+    private string _paginationKey;
 
     [OneTimeSetUp]
-    public void Setup()
+    public void OneTimeSetup()
     {
-        var configuration = new Configuration(Environment.GetEnvironmentVariable("SECRET_API_KEY")!);
+        var apiKey = Environment.GetEnvironmentVariable("SECRET_API_KEY");
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            Assert.Fail("SECRET_API_KEY is not set. Provide it via environment.");
+        }
 
-        _api = new FingerprintApi(
-            configuration
-        );
+        var configuration = new Configuration(apiKey!);
+        _api = new FingerprintApi(configuration);
 
         var now = DateTimeOffset.UtcNow;
-        end = now.ToUnixTimeMilliseconds();
-        start = now.AddDays(-90).ToUnixTimeMilliseconds();
+        _end = now.ToUnixTimeMilliseconds();
+        _start = now.AddDays(-90).ToUnixTimeMilliseconds();
 
-        var events = _api.SearchEvents(2, start: start, end: end);
-        Assert.That(events.Events, Is.Not.Empty);
-        var firstEventIdentificationData = events.Events[0].Products.Identification.Data;
-        requestId = firstEventIdentificationData.RequestId;
-        visitorId = firstEventIdentificationData.VisitorId;
+        var events = _api.SearchEvents(2, start: _start, end: _end);
+        Assert.That(events.Events, Is.Not.Null.And.Not.Empty, "No events returned by SearchEvents.");
+
+        var first = events.Events[0].Products.Identification.Data;
+        _requestId = first.RequestId;
+        _visitorId = first.VisitorId;
+        _paginationKey = events.PaginationKey;
     }
 
     [Test]
-    public void GetEventsTest()
+    public void GetEvent_ReturnsExpectedFields()
     {
-        var events = _api.GetEvent(requestId);
+        var events = _api.GetEvent(_requestId);
 
         Assert.Multiple(() =>
         {
@@ -44,85 +50,98 @@ public class ApiTests
             Assert.That(events.Products, Is.InstanceOf<Products>());
             Assert.That(events.Products.Botd, Is.InstanceOf<ProductBotd>());
             Assert.That(events.Products.Identification, Is.InstanceOf<ProductIdentification>());
-            Assert.That(events.Products.Identification.Data.RequestId, Is.EqualTo(requestId));
+            Assert.That(events.Products.Identification.Data.RequestId, Is.EqualTo(_requestId));
         });
     }
 
     [Test]
-    public void GetEvents404Test()
+    public void GetEvent_WrongRequestId_Throws404()
     {
-        var getEvents = () => _api.GetEventAsync("1662542583652.pLBzes");
-
-        Assert.That(getEvents,
-            Throws.TypeOf<ApiException>().With.Message.Contains("request id not found")
+        Assert.That(async () => await _api.GetEventAsync("1662542583652.pLBzes"),
+            Throws.TypeOf<ApiException>()
+                .With.Message.Contains("request id not found")
                 .And.Property(nameof(ApiException.HttpCode)).EqualTo(404)
                 .And.Property(nameof(ApiException.ErrorCode)).EqualTo(ErrorCode.RequestNotFound)
                 .And.Property(nameof(ApiException.ErrorContent)).InstanceOf(typeof(ErrorResponse)));
     }
 
     [Test]
-    public void GetVisitsWithoutRequestIdTest()
+    public void GetVisits_WithoutRequestId()
     {
-        var response = _api.GetVisits(visitorId);
+        var response = _api.GetVisits(_visitorId);
 
         Assert.Multiple(() =>
         {
             Assert.That(response, Is.InstanceOf<VisitorsGetResponse>());
             Assert.That(response.Visits, Is.All.InstanceOf<Visit>());
-            Assert.That(response.VisitorId, Is.EqualTo(visitorId));
+            Assert.That(response.VisitorId, Is.EqualTo(_visitorId));
         });
     }
 
     [Test]
-    public void GetVisitsWithRequestIdTest()
+    public void GetVisits_WithRequestId()
     {
-        var allVisits = _api.GetVisits(visitorId);
+        var allVisits = _api.GetVisits(_visitorId);
+        Assert.That(allVisits.Visits, Is.Not.Null.And.Not.Empty, "Expected at least one visit for visitor.");
 
         var requestId = allVisits.Visits[0].RequestId;
 
-        var response = _api.GetVisits(visitorId, requestId);
+        var response = _api.GetVisits(_visitorId, requestId);
 
         Assert.Multiple(() =>
         {
             Assert.That(response, Is.InstanceOf<VisitorsGetResponse>());
             Assert.That(response.Visits, Has.Count.EqualTo(1));
             Assert.That(response.Visits[0].RequestId, Is.EqualTo(requestId));
-            Assert.That(response.VisitorId, Is.EqualTo(visitorId));
+            Assert.That(response.VisitorId, Is.EqualTo(_visitorId));
         });
     }
 
     [Test]
-    public void SearchEvents()
+    public void SearchEvents_Returns()
     {
-        var limit = 2;
         var start = DateTime.UtcNow.Subtract(TimeSpan.FromDays(365));
         var end = DateTime.UtcNow.Add(TimeSpan.FromDays(365));
 
-        var response = _api.SearchEvents(limit, start: ((DateTimeOffset)start).ToUnixTimeMilliseconds(),
-            end: ((DateTimeOffset)end).ToUnixTimeMilliseconds());
+        var response = _api.SearchEvents(
+            limit: 2,
+            start: new DateTimeOffset(start, TimeSpan.Zero).ToUnixTimeMilliseconds(),
+            end: new DateTimeOffset(end, TimeSpan.Zero).ToUnixTimeMilliseconds()
+        );
 
-        Assert.That(response.Events.Count, Is.GreaterThanOrEqualTo(1));
+        Assert.That(response.Events, Is.Not.Empty);
     }
 
     [Test]
-    public void SearchEventsPagination()
+    public void SearchEvents_Pagination()
     {
-        var response = _api.SearchEvents(2, start: start, end: end, paginationKey: searchEventsPaginationKey);
-        Assert.That(response.Events.Count, Is.GreaterThanOrEqualTo(1));
+        if (string.IsNullOrEmpty(_paginationKey))
+        {
+            Assert.Inconclusive("Initial SearchEvents response did not include a pagination key.");
+        }
+
+        var response = _api.SearchEvents(2, start: _start, end: _end, paginationKey: _paginationKey);
+        Assert.That(response.Events, Is.Not.Empty);
     }
 
     [Test]
-    public void SearchOldEvents()
+    public void SearchEvents_ReverseWorks()
     {
-        var response = _api.SearchEvents(limit: 2, start: start, end: end, reverse: true);
+        var response = _api.SearchEvents(limit: 2, start: _start, end: _end, reverse: true);
+        Assert.That(response.Events, Has.Count.EqualTo(2));
 
-        Assert.That(response.Events.Count, Is.GreaterThanOrEqualTo(1));
-        var oldEventIdentificationData = response.Events[0].Products.Identification.Data;
+        var oldestEventIdentificationData = response.Events[0].Products.Identification.Data;
+        var secondOldestEventIdentificationData = response.Events[1].Products.Identification.Data;
 
-        Assert.That(oldEventIdentificationData.RequestId, Is.Not.EqualTo(requestId));
+        Assert.Multiple(() =>
+        {
+            Assert.That(oldestEventIdentificationData.Timestamp, Is.Not.Null);
+            Assert.That(secondOldestEventIdentificationData.Timestamp, Is.Not.Null);
+        });
+        Assert.That(oldestEventIdentificationData.Timestamp, Is.LessThan(secondOldestEventIdentificationData.Timestamp));
 
         // Try to request old events to check if they still could be deserialized
-        _api.GetVisits(oldEventIdentificationData.VisitorId);
-        _api.GetEvent(oldEventIdentificationData.RequestId);
+        _api.GetVisits(oldestEventIdentificationData.VisitorId);
+        _api.GetEvent(oldestEventIdentificationData.RequestId);
     }
 }


### PR DESCRIPTION
Made the functional test script simpler. We no longer compare `visitorId` between recent and oldest events. 