### PR TITLE
INTER-1896: Use repeated keys instead of bracket notation

### DIFF
--- a/.changeset/four-boxes-tan.md
+++ b/.changeset/four-boxes-tan.md
@@ -1,5 +1,5 @@
 ---
-"fingerprint-server-dotnet-sdk": minor
+"fingerprint-server-dotnet-sdk": patch
 ---
 
 **events-search:** use repeated keys for array parameter serialization

--- a/.changeset/four-boxes-tan.md
+++ b/.changeset/four-boxes-tan.md
@@ -1,0 +1,5 @@
+---
+"fingerprint-server-dotnet-sdk": minor
+---
+
+**events-search:** use repeated keys for array parameter serialization

--- a/src/Fingerprint.ServerSdk.Test/Api/FingerprintApiTests.cs
+++ b/src/Fingerprint.ServerSdk.Test/Api/FingerprintApiTests.cs
@@ -312,8 +312,8 @@ namespace Fingerprint.ServerSdk.Test.Api
                 + $"&proxy={proxy.ToString().ToLower()}"
                 + $"&sdk_version={sdkVersion}"
                 + $"&sdk_platform={SearchEventsSdkPlatformValueConverter.ToJsonValue(sdkPlatform)}"
-                + $"&environment[]={environment[0]}"
-                + $"&environment[]={environment[1]}"
+                + $"&environment={environment[0]}"
+                + $"&environment={environment[1]}"
                 + $"&proximity_id={proximityId}"
                 + $"&total_hits={totalHits}"
                 + $"&tor_node={torNode.ToString().ToLower()}";

--- a/src/Fingerprint.ServerSdk/Api/FingerprintApi.cs
+++ b/src/Fingerprint.ServerSdk/Api/FingerprintApi.cs
@@ -2347,7 +2347,7 @@ namespace Fingerprint.ServerSdk.Api
                     {
                         foreach (var item in environment.Value)
                         {
-                            parseQueryStringLocalVar.Add("environment[]", ClientUtils.ParameterToString(item));
+                            parseQueryStringLocalVar.Add("environment", ClientUtils.ParameterToString(item));
                         }
                     }
 

--- a/template/api.mustache
+++ b/template/api.mustache
@@ -484,7 +484,7 @@ namespace {{packageName}}.{{apiPackage}}
                     {{#isArray}}
                     foreach (var item in {{paramName}})
                     {
-                        parseQueryStringLocalVar.Add("{{baseName}}[]", ClientUtils.ParameterToString(item));
+                        parseQueryStringLocalVar.Add("{{baseName}}", ClientUtils.ParameterToString(item));
                     }
                     {{/isArray}}
                     {{^isArray}}
@@ -506,7 +506,7 @@ namespace {{packageName}}.{{apiPackage}}
                     {
                         foreach (var item in {{paramName}}.Value)
                         {
-                            parseQueryStringLocalVar.Add("{{baseName}}[]", ClientUtils.ParameterToString(item));
+                            parseQueryStringLocalVar.Add("{{baseName}}", ClientUtils.ParameterToString(item));
                         }
                     }
                     {{/isArray}}


### PR DESCRIPTION
## Summary
- Array query parameters were serialized using bracket notation instead of repeated keys.
