### PR TITLE
fix: update reference to .sln in Dockerfile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,4 @@ SECRET_API_KEY=<YOUR_API_KEY>
 VISITOR_ID=<YOUR_VISITOR_ID>
 EVENT_ID=<YOUR_EVENT_ID>
 RULESET_ID=<YOUR_RULESET_ID>
-REGION=<YOUR_REGION> # if different than `us`
+REGION=us # change to eu or ap if your region is not us/global

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 # Copy the project file and restore dependencies
-COPY ["fingerprint-server-dotnet-sdk.sln", "./"]
+COPY ["Fingerprint.ServerSdk.sln", "./"]
 # LICENSE is required for building the package
 COPY ["LICENSE", "./"]
 COPY ["res", "res/"]


### PR DESCRIPTION
- Update Dockerfile to use renamed .sln file name
- Update .env.example to default to "us" region. The example now requires the region to be valid or it throws an exception.