### PR TITLE
fix: tolerate extra files in docs/apis during generation INTER-2002

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -16,4 +16,4 @@ docker run --rm -u "$(id -u):$(id -g)" -v "${PWD}:/local" -w /local "openapitool
 
 # Fix api doc
 mv ./docs/apis/FingerprintApi.md ./docs/FingerprintApi.md
-rmdir ./docs/apis
+rm -rf ./docs/apis


### PR DESCRIPTION
## Summary

- `rmdir ./docs/apis` failed in [the schema sync](https://github.com/fingerprintjs/fingerprint-pro-server-api-openapi/actions/runs/25041817841/job/73346709889) because v3.0.1's schema has an untagged webhook operation, so the generator emits `DefaultApi.md` alongside `FingerprintApi.md`.
- Switch to `rm -rf` so `generate.sh` tolerates any extra files the generator drops in `docs/apis/`.

## Test plan

- [ ] Re-run the Sync Server-Side SDKs schema workflow and confirm the dotnet job completes through v3.0.1 → v3.1.0 → v3.2.0.