### PR TITLE
Replace import assertion in `bumpConfig`

### DIFF
--- a/bumpConfig.mjs
+++ b/bumpConfig.mjs
@@ -1,5 +1,5 @@
-import config from './config.json' assert {type: 'json'};
-import pkg from './package.json' assert {type: 'json'};
+import config from './config.json' with {type: 'json'};
+import pkg from './package.json' with {type: 'json'};
 import fs from 'fs'
 import cp from 'child_process'
 import { fileURLToPath } from 'url';


### PR DESCRIPTION
Node 22 removed the `assert` keyword for import assertions. This broke the CI pipeline since our GH Actions [runs on Node 22](https://github.com/fingerprintjs/dotnet-sdk/actions/runs/26456487564/job/77899052882#step:8:43).

[Node.js Blog Reference](https://nodejs.org/en/blog/migrations/v20-to-v22#import-assertions-to-attributes)