### PR TITLE
feat: allow unknown enum values

### DIFF
--- a/.changeset/unknown-enum-values.md
+++ b/.changeset/unknown-enum-values.md
@@ -1,0 +1,5 @@
+---
+'fingerprint-server-dotnet-sdk': patch
+---
+
+Support deserializing enum values that are not yet known to the SDK. When the API returns an enum value this SDK version does not recognize (including on required fields such as `proxy_details.proxy_type`), it now deserializes to the catch-all `UnsupportedValueSdkUpgradeRequired` member instead of throwing.

--- a/src/Fingerprint.ServerSdk.Test/Api/ApiTestsBase.cs
+++ b/src/Fingerprint.ServerSdk.Test/Api/ApiTestsBase.cs
@@ -80,9 +80,18 @@ namespace Fingerprint.ServerSdk.Test.Api
 
         protected void SetupMockResponse(string fileName)
         {
+            _mockResponseBytes = Encoding.UTF8.GetBytes(ReadMockFile(fileName));
+        }
+
+        protected void SetupMockResponseFromString(string body)
+        {
+            _mockResponseBytes = Encoding.UTF8.GetBytes(body);
+        }
+
+        protected static string ReadMockFile(string fileName)
+        {
             var path = Path.Combine(AppContext.BaseDirectory, "mocks", fileName);
-            var mockResponse = File.ReadAllText(path);
-            _mockResponseBytes = Encoding.UTF8.GetBytes(mockResponse);
+            return File.ReadAllText(path);
         }
 
         private async Task HandleConnection()

--- a/src/Fingerprint.ServerSdk.Test/Api/FingerprintApiTests.cs
+++ b/src/Fingerprint.ServerSdk.Test/Api/FingerprintApiTests.cs
@@ -208,6 +208,8 @@ namespace Fingerprint.ServerSdk.Test.Api
                 // Before the fix, Ok() threw and TryOk() returned false with a null result.
                 Assert.True(response.TryOk(out var tryModel));
                 Assert.NotNull(tryModel);
+                Assert.Equal(ProxyDetails.ProxyTypeEnum.UnsupportedValueSdkUpgradeRequired,
+                    tryModel.ProxyDetails.ProxyType);
 
                 var model = response.Ok();
                 Assert.NotNull(model);

--- a/src/Fingerprint.ServerSdk.Test/Api/FingerprintApiTests.cs
+++ b/src/Fingerprint.ServerSdk.Test/Api/FingerprintApiTests.cs
@@ -189,6 +189,34 @@ namespace Fingerprint.ServerSdk.Test.Api
                     model.FactoryResetTimestamp);
             });
         }
+        
+        [Fact]
+        public async Task GetEventWithUnsupportedProxyTypeAsyncTest()
+        {
+            var json = ReadMockFile("events/get_event_200.json")
+                .Replace("\"proxy_type\": \"residential\"", "\"proxy_type\": \"unknown\"");
+            SetupMockResponseFromString(json);
+
+            const string eventId = "1708102555327.NLOjmg";
+            var response = await _instance.GetEventAsync(eventId);
+
+            Assert.Multiple(() =>
+            {
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                Assert.True(response.IsOk);
+
+                // Before the fix, Ok() threw and TryOk() returned false with a null result.
+                Assert.True(response.TryOk(out var tryModel));
+                Assert.NotNull(tryModel);
+
+                var model = response.Ok();
+                Assert.NotNull(model);
+                Assert.IsType<Event>(model);
+                Assert.Equal(eventId, model.EventId);
+                Assert.Equal(ProxyDetails.ProxyTypeEnum.UnsupportedValueSdkUpgradeRequired,
+                    model.ProxyDetails.ProxyType);
+            });
+        }
 
         [Fact]
         public async Task SearchEventsAsyncTest()

--- a/src/Fingerprint.ServerSdk.Test/EnumDeserializationTests.cs
+++ b/src/Fingerprint.ServerSdk.Test/EnumDeserializationTests.cs
@@ -1,0 +1,59 @@
+using System.Text.Json;
+using Fingerprint.ServerSdk.Model;
+using Xunit;
+
+namespace Fingerprint.ServerSdk.Test;
+
+public class EnumDeserializationTests
+{
+    [Fact]
+    public void ProxyTypeEnumFromStringOrDefault_UnknownValue_ReturnsCatchAll()
+    {
+        Assert.Equal(
+            ProxyDetails.ProxyTypeEnum.UnsupportedValueSdkUpgradeRequired,
+            ProxyDetails.ProxyTypeEnumFromStringOrDefault("some_future_value"));
+    }
+
+    [Fact]
+    public void ProxyTypeEnumFromStringOrDefault_KnownValue_ReturnsMappedMember()
+    {
+        Assert.Equal(
+            ProxyDetails.ProxyTypeEnum.Residential,
+            ProxyDetails.ProxyTypeEnumFromStringOrDefault("residential"));
+    }
+
+    [Fact]
+    public void DeserializeProxyDetails_UnknownRequiredProxyType_DoesNotThrowAndMapsToCatchAll()
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new ProxyDetailsJsonConverter());
+
+        const string json = "{\"proxy_type\":\"some_future_value\",\"last_seen_at\":1708102555327}";
+
+        var proxyDetails = JsonSerializer.Deserialize<ProxyDetails>(json, options);
+
+        Assert.NotNull(proxyDetails);
+        Assert.Equal(
+            ProxyDetails.ProxyTypeEnum.UnsupportedValueSdkUpgradeRequired,
+            proxyDetails!.ProxyType);
+    }
+    
+    [Fact]
+    public void StandaloneEnumValueConverter_UnknownValue_ReturnsCatchAll()
+    {
+        Assert.Equal(
+            ProxyConfidence.UnsupportedValueSdkUpgradeRequired,
+            ProxyConfidenceValueConverter.FromStringOrDefault("some_future_value"));
+    }
+
+    [Fact]
+    public void DeserializeStandaloneEnum_UnknownValue_DoesNotThrowAndMapsToCatchAll()
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new ProxyConfidenceJsonConverter());
+
+        var confidence = JsonSerializer.Deserialize<ProxyConfidence>("\"some_future_value\"", options);
+
+        Assert.Equal(ProxyConfidence.UnsupportedValueSdkUpgradeRequired, confidence);
+    }
+}

--- a/src/Fingerprint.ServerSdk.Test/EnumDeserializationTests.cs
+++ b/src/Fingerprint.ServerSdk.Test/EnumDeserializationTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json;
 using Fingerprint.ServerSdk.Model;
 using Xunit;
@@ -55,5 +56,21 @@ public class EnumDeserializationTests
         var confidence = JsonSerializer.Deserialize<ProxyConfidence>("\"some_future_value\"", options);
 
         Assert.Equal(ProxyConfidence.UnsupportedValueSdkUpgradeRequired, confidence);
+    }
+
+    [Fact]
+    public void SerializeInnerEnumCatchAll_Throws()
+    {
+        Assert.Throws<NotImplementedException>(() =>
+            ProxyDetails.ProxyTypeEnumToJsonValue(
+                ProxyDetails.ProxyTypeEnum.UnsupportedValueSdkUpgradeRequired));
+    }
+
+    [Fact]
+    public void SerializeStandaloneEnumCatchAll_Throws()
+    {
+        Assert.Throws<NotImplementedException>(() =>
+            ProxyConfidenceValueConverter.ToJsonValue(
+                ProxyConfidence.UnsupportedValueSdkUpgradeRequired));
     }
 }

--- a/src/Fingerprint.ServerSdk.Test/EnumDeserializationTests.cs
+++ b/src/Fingerprint.ServerSdk.Test/EnumDeserializationTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Text.Json;
 using Fingerprint.ServerSdk.Model;
 using Xunit;
@@ -59,18 +58,29 @@ public class EnumDeserializationTests
     }
 
     [Fact]
-    public void SerializeInnerEnumCatchAll_Throws()
+    public void SerializeInnerEnumCatchAll_WritesUnknownValue()
     {
-        Assert.Throws<NotImplementedException>(() =>
+        Assert.Equal(
+            "unsupported_value_sdk_upgrade_required",
             ProxyDetails.ProxyTypeEnumToJsonValue(
                 ProxyDetails.ProxyTypeEnum.UnsupportedValueSdkUpgradeRequired));
     }
 
     [Fact]
-    public void SerializeStandaloneEnumCatchAll_Throws()
+    public void SerializeStandaloneEnumCatchAll_WritesUnknownValue()
     {
-        Assert.Throws<NotImplementedException>(() =>
+        Assert.Equal(
+            "unsupported_value_sdk_upgrade_required",
             ProxyConfidenceValueConverter.ToJsonValue(
                 ProxyConfidence.UnsupportedValueSdkUpgradeRequired));
+    }
+
+    [Fact]
+    public void RoundTripCatchAll_DeserializesBackToCatchAll()
+    {
+        // Re-deserializing the Unknown string maps back to the catch-all member.
+        Assert.Equal(
+            ProxyDetails.ProxyTypeEnum.UnsupportedValueSdkUpgradeRequired,
+            ProxyDetails.ProxyTypeEnumFromStringOrDefault("unsupported_value_sdk_upgrade_required"));
     }
 }

--- a/src/Fingerprint.ServerSdk/Model/BotInfo.cs
+++ b/src/Fingerprint.ServerSdk/Model/BotInfo.cs
@@ -81,7 +81,12 @@ namespace Fingerprint.ServerSdk.Model
             /// Enum Unknown for value: unknown
             /// </summary>
 
-            Unknown = 4
+            Unknown = 4,
+
+            /// <summary>
+            /// Catch-all value used when the API returns an enum value that this version of the SDK does not recognize. Upgrade the SDK to a version that supports the value.
+            /// </summary>
+            UnsupportedValueSdkUpgradeRequired = -1
         }
 
         /// <summary>
@@ -126,7 +131,7 @@ namespace Fingerprint.ServerSdk.Model
             if (value.Equals("unknown"))
                 return IdentityEnum.Unknown;
 
-            return null;
+            return IdentityEnum.UnsupportedValueSdkUpgradeRequired;
         }
 
         /// <summary>
@@ -181,7 +186,12 @@ namespace Fingerprint.ServerSdk.Model
             /// Enum High for value: high
             /// </summary>
 
-            High = 3
+            High = 3,
+
+            /// <summary>
+            /// Catch-all value used when the API returns an enum value that this version of the SDK does not recognize. Upgrade the SDK to a version that supports the value.
+            /// </summary>
+            UnsupportedValueSdkUpgradeRequired = -1
         }
 
         /// <summary>
@@ -220,7 +230,7 @@ namespace Fingerprint.ServerSdk.Model
             if (value.Equals("high"))
                 return ConfidenceEnum.High;
 
-            return null;
+            return ConfidenceEnum.UnsupportedValueSdkUpgradeRequired;
         }
 
         /// <summary>

--- a/src/Fingerprint.ServerSdk/Model/BotInfo.cs
+++ b/src/Fingerprint.ServerSdk/Model/BotInfo.cs
@@ -154,8 +154,11 @@ namespace Fingerprint.ServerSdk.Model
             if (value == IdentityEnum.Unknown)
                 return "unknown";
 
+            // Serialize the catch-all value rather than throwing, so models holding an enum value
+            // this SDK version does not support can still be re-serialized. The original (unsupported)
+            // value is not preserved.
             if (value == IdentityEnum.UnsupportedValueSdkUpgradeRequired)
-                throw new NotImplementedException("Cannot serialize IdentityEnum.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+                return "unsupported_value_sdk_upgrade_required";
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }
@@ -253,8 +256,11 @@ namespace Fingerprint.ServerSdk.Model
             if (value == ConfidenceEnum.High)
                 return "high";
 
+            // Serialize the catch-all value rather than throwing, so models holding an enum value
+            // this SDK version does not support can still be re-serialized. The original (unsupported)
+            // value is not preserved.
             if (value == ConfidenceEnum.UnsupportedValueSdkUpgradeRequired)
-                throw new NotImplementedException("Cannot serialize ConfidenceEnum.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+                return "unsupported_value_sdk_upgrade_required";
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }

--- a/src/Fingerprint.ServerSdk/Model/BotInfo.cs
+++ b/src/Fingerprint.ServerSdk/Model/BotInfo.cs
@@ -154,6 +154,9 @@ namespace Fingerprint.ServerSdk.Model
             if (value == IdentityEnum.Unknown)
                 return "unknown";
 
+            if (value == IdentityEnum.UnsupportedValueSdkUpgradeRequired)
+                throw new NotImplementedException("Cannot serialize IdentityEnum.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }
 
@@ -249,6 +252,9 @@ namespace Fingerprint.ServerSdk.Model
 
             if (value == ConfidenceEnum.High)
                 return "high";
+
+            if (value == ConfidenceEnum.UnsupportedValueSdkUpgradeRequired)
+                throw new NotImplementedException("Cannot serialize ConfidenceEnum.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }

--- a/src/Fingerprint.ServerSdk/Model/BotInfoCategory.cs
+++ b/src/Fingerprint.ServerSdk/Model/BotInfoCategory.cs
@@ -292,6 +292,9 @@ namespace Fingerprint.ServerSdk.Model
             if (value == BotInfoCategory.Unknown)
                 return "unknown";
 
+            if (value == BotInfoCategory.UnsupportedValueSdkUpgradeRequired)
+                throw new NotImplementedException("Cannot serialize BotInfoCategory.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }
     }

--- a/src/Fingerprint.ServerSdk/Model/BotInfoCategory.cs
+++ b/src/Fingerprint.ServerSdk/Model/BotInfoCategory.cs
@@ -107,7 +107,12 @@ namespace Fingerprint.ServerSdk.Model
         /// <summary>
         /// Enum Unknown for value: unknown
         /// </summary>
-        Unknown = 16
+        Unknown = 16,
+
+        /// <summary>
+        /// Catch-all value used when the API returns an enum value that this version of the SDK does not recognize. Upgrade the SDK to a version that supports the value.
+        /// </summary>
+        UnsupportedValueSdkUpgradeRequired = -1
     }
 
     /// <summary>
@@ -228,7 +233,7 @@ namespace Fingerprint.ServerSdk.Model
             if (value.Equals("unknown"))
                 return BotInfoCategory.Unknown;
 
-            return null;
+            return BotInfoCategory.UnsupportedValueSdkUpgradeRequired;
         }
 
         /// <summary>

--- a/src/Fingerprint.ServerSdk/Model/BotInfoCategory.cs
+++ b/src/Fingerprint.ServerSdk/Model/BotInfoCategory.cs
@@ -292,8 +292,11 @@ namespace Fingerprint.ServerSdk.Model
             if (value == BotInfoCategory.Unknown)
                 return "unknown";
 
+            // Serialize the catch-all value rather than throwing, so models holding an enum value
+            // this SDK version does not support can still be re-serialized. The original (unsupported)
+            // value is not preserved.
             if (value == BotInfoCategory.UnsupportedValueSdkUpgradeRequired)
-                throw new NotImplementedException("Cannot serialize BotInfoCategory.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+                return "unsupported_value_sdk_upgrade_required";
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }

--- a/src/Fingerprint.ServerSdk/Model/BotInfoConfidence.cs
+++ b/src/Fingerprint.ServerSdk/Model/BotInfoConfidence.cs
@@ -110,6 +110,9 @@ namespace Fingerprint.ServerSdk.Model
             if (value == BotInfoConfidence.High)
                 return "high";
 
+            if (value == BotInfoConfidence.UnsupportedValueSdkUpgradeRequired)
+                throw new NotImplementedException("Cannot serialize BotInfoConfidence.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }
     }

--- a/src/Fingerprint.ServerSdk/Model/BotInfoConfidence.cs
+++ b/src/Fingerprint.ServerSdk/Model/BotInfoConfidence.cs
@@ -42,7 +42,12 @@ namespace Fingerprint.ServerSdk.Model
         /// <summary>
         /// Enum High for value: high
         /// </summary>
-        High = 3
+        High = 3,
+
+        /// <summary>
+        /// Catch-all value used when the API returns an enum value that this version of the SDK does not recognize. Upgrade the SDK to a version that supports the value.
+        /// </summary>
+        UnsupportedValueSdkUpgradeRequired = -1
     }
 
     /// <summary>
@@ -85,7 +90,7 @@ namespace Fingerprint.ServerSdk.Model
             if (value.Equals("high"))
                 return BotInfoConfidence.High;
 
-            return null;
+            return BotInfoConfidence.UnsupportedValueSdkUpgradeRequired;
         }
 
         /// <summary>

--- a/src/Fingerprint.ServerSdk/Model/BotInfoConfidence.cs
+++ b/src/Fingerprint.ServerSdk/Model/BotInfoConfidence.cs
@@ -110,8 +110,11 @@ namespace Fingerprint.ServerSdk.Model
             if (value == BotInfoConfidence.High)
                 return "high";
 
+            // Serialize the catch-all value rather than throwing, so models holding an enum value
+            // this SDK version does not support can still be re-serialized. The original (unsupported)
+            // value is not preserved.
             if (value == BotInfoConfidence.UnsupportedValueSdkUpgradeRequired)
-                throw new NotImplementedException("Cannot serialize BotInfoConfidence.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+                return "unsupported_value_sdk_upgrade_required";
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }

--- a/src/Fingerprint.ServerSdk/Model/BotInfoIdentity.cs
+++ b/src/Fingerprint.ServerSdk/Model/BotInfoIdentity.cs
@@ -124,8 +124,11 @@ namespace Fingerprint.ServerSdk.Model
             if (value == BotInfoIdentity.Unknown)
                 return "unknown";
 
+            // Serialize the catch-all value rather than throwing, so models holding an enum value
+            // this SDK version does not support can still be re-serialized. The original (unsupported)
+            // value is not preserved.
             if (value == BotInfoIdentity.UnsupportedValueSdkUpgradeRequired)
-                throw new NotImplementedException("Cannot serialize BotInfoIdentity.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+                return "unsupported_value_sdk_upgrade_required";
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }

--- a/src/Fingerprint.ServerSdk/Model/BotInfoIdentity.cs
+++ b/src/Fingerprint.ServerSdk/Model/BotInfoIdentity.cs
@@ -124,6 +124,9 @@ namespace Fingerprint.ServerSdk.Model
             if (value == BotInfoIdentity.Unknown)
                 return "unknown";
 
+            if (value == BotInfoIdentity.UnsupportedValueSdkUpgradeRequired)
+                throw new NotImplementedException("Cannot serialize BotInfoIdentity.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }
     }

--- a/src/Fingerprint.ServerSdk/Model/BotInfoIdentity.cs
+++ b/src/Fingerprint.ServerSdk/Model/BotInfoIdentity.cs
@@ -47,7 +47,12 @@ namespace Fingerprint.ServerSdk.Model
         /// <summary>
         /// Enum Unknown for value: unknown
         /// </summary>
-        Unknown = 4
+        Unknown = 4,
+
+        /// <summary>
+        /// Catch-all value used when the API returns an enum value that this version of the SDK does not recognize. Upgrade the SDK to a version that supports the value.
+        /// </summary>
+        UnsupportedValueSdkUpgradeRequired = -1
     }
 
     /// <summary>
@@ -96,7 +101,7 @@ namespace Fingerprint.ServerSdk.Model
             if (value.Equals("unknown"))
                 return BotInfoIdentity.Unknown;
 
-            return null;
+            return BotInfoIdentity.UnsupportedValueSdkUpgradeRequired;
         }
 
         /// <summary>

--- a/src/Fingerprint.ServerSdk/Model/BotResult.cs
+++ b/src/Fingerprint.ServerSdk/Model/BotResult.cs
@@ -110,8 +110,11 @@ namespace Fingerprint.ServerSdk.Model
             if (value == BotResult.NotDetected)
                 return "not_detected";
 
+            // Serialize the catch-all value rather than throwing, so models holding an enum value
+            // this SDK version does not support can still be re-serialized. The original (unsupported)
+            // value is not preserved.
             if (value == BotResult.UnsupportedValueSdkUpgradeRequired)
-                throw new NotImplementedException("Cannot serialize BotResult.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+                return "unsupported_value_sdk_upgrade_required";
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }

--- a/src/Fingerprint.ServerSdk/Model/BotResult.cs
+++ b/src/Fingerprint.ServerSdk/Model/BotResult.cs
@@ -42,7 +42,12 @@ namespace Fingerprint.ServerSdk.Model
         /// <summary>
         /// Enum NotDetected for value: not_detected
         /// </summary>
-        NotDetected = 3
+        NotDetected = 3,
+
+        /// <summary>
+        /// Catch-all value used when the API returns an enum value that this version of the SDK does not recognize. Upgrade the SDK to a version that supports the value.
+        /// </summary>
+        UnsupportedValueSdkUpgradeRequired = -1
     }
 
     /// <summary>
@@ -85,7 +90,7 @@ namespace Fingerprint.ServerSdk.Model
             if (value.Equals("not_detected"))
                 return BotResult.NotDetected;
 
-            return null;
+            return BotResult.UnsupportedValueSdkUpgradeRequired;
         }
 
         /// <summary>

--- a/src/Fingerprint.ServerSdk/Model/BotResult.cs
+++ b/src/Fingerprint.ServerSdk/Model/BotResult.cs
@@ -110,6 +110,9 @@ namespace Fingerprint.ServerSdk.Model
             if (value == BotResult.NotDetected)
                 return "not_detected";
 
+            if (value == BotResult.UnsupportedValueSdkUpgradeRequired)
+                throw new NotImplementedException("Cannot serialize BotResult.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }
     }

--- a/src/Fingerprint.ServerSdk/Model/ErrorCode.cs
+++ b/src/Fingerprint.ServerSdk/Model/ErrorCode.cs
@@ -117,7 +117,12 @@ namespace Fingerprint.ServerSdk.Model
         /// <summary>
         /// Enum RulesetNotFound for value: ruleset_not_found
         /// </summary>
-        RulesetNotFound = 18
+        RulesetNotFound = 18,
+
+        /// <summary>
+        /// Catch-all value used when the API returns an enum value that this version of the SDK does not recognize. Upgrade the SDK to a version that supports the value.
+        /// </summary>
+        UnsupportedValueSdkUpgradeRequired = -1
     }
 
     /// <summary>
@@ -250,7 +255,7 @@ namespace Fingerprint.ServerSdk.Model
             if (value.Equals("ruleset_not_found"))
                 return ErrorCode.RulesetNotFound;
 
-            return null;
+            return ErrorCode.UnsupportedValueSdkUpgradeRequired;
         }
 
         /// <summary>

--- a/src/Fingerprint.ServerSdk/Model/ErrorCode.cs
+++ b/src/Fingerprint.ServerSdk/Model/ErrorCode.cs
@@ -320,8 +320,11 @@ namespace Fingerprint.ServerSdk.Model
             if (value == ErrorCode.RulesetNotFound)
                 return "ruleset_not_found";
 
+            // Serialize the catch-all value rather than throwing, so models holding an enum value
+            // this SDK version does not support can still be re-serialized. The original (unsupported)
+            // value is not preserved.
             if (value == ErrorCode.UnsupportedValueSdkUpgradeRequired)
-                throw new NotImplementedException("Cannot serialize ErrorCode.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+                return "unsupported_value_sdk_upgrade_required";
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }

--- a/src/Fingerprint.ServerSdk/Model/ErrorCode.cs
+++ b/src/Fingerprint.ServerSdk/Model/ErrorCode.cs
@@ -320,6 +320,9 @@ namespace Fingerprint.ServerSdk.Model
             if (value == ErrorCode.RulesetNotFound)
                 return "ruleset_not_found";
 
+            if (value == ErrorCode.UnsupportedValueSdkUpgradeRequired)
+                throw new NotImplementedException("Cannot serialize ErrorCode.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }
     }

--- a/src/Fingerprint.ServerSdk/Model/IncrementalIdentificationStatus.cs
+++ b/src/Fingerprint.ServerSdk/Model/IncrementalIdentificationStatus.cs
@@ -96,6 +96,9 @@ namespace Fingerprint.ServerSdk.Model
             if (value == IncrementalIdentificationStatus.Completed)
                 return "completed";
 
+            if (value == IncrementalIdentificationStatus.UnsupportedValueSdkUpgradeRequired)
+                throw new NotImplementedException("Cannot serialize IncrementalIdentificationStatus.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }
     }

--- a/src/Fingerprint.ServerSdk/Model/IncrementalIdentificationStatus.cs
+++ b/src/Fingerprint.ServerSdk/Model/IncrementalIdentificationStatus.cs
@@ -96,8 +96,11 @@ namespace Fingerprint.ServerSdk.Model
             if (value == IncrementalIdentificationStatus.Completed)
                 return "completed";
 
+            // Serialize the catch-all value rather than throwing, so models holding an enum value
+            // this SDK version does not support can still be re-serialized. The original (unsupported)
+            // value is not preserved.
             if (value == IncrementalIdentificationStatus.UnsupportedValueSdkUpgradeRequired)
-                throw new NotImplementedException("Cannot serialize IncrementalIdentificationStatus.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+                return "unsupported_value_sdk_upgrade_required";
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }

--- a/src/Fingerprint.ServerSdk/Model/IncrementalIdentificationStatus.cs
+++ b/src/Fingerprint.ServerSdk/Model/IncrementalIdentificationStatus.cs
@@ -37,7 +37,12 @@ namespace Fingerprint.ServerSdk.Model
         /// <summary>
         /// Enum Completed for value: completed
         /// </summary>
-        Completed = 2
+        Completed = 2,
+
+        /// <summary>
+        /// Catch-all value used when the API returns an enum value that this version of the SDK does not recognize. Upgrade the SDK to a version that supports the value.
+        /// </summary>
+        UnsupportedValueSdkUpgradeRequired = -1
     }
 
     /// <summary>
@@ -74,7 +79,7 @@ namespace Fingerprint.ServerSdk.Model
             if (value.Equals("completed"))
                 return IncrementalIdentificationStatus.Completed;
 
-            return null;
+            return IncrementalIdentificationStatus.UnsupportedValueSdkUpgradeRequired;
         }
 
         /// <summary>

--- a/src/Fingerprint.ServerSdk/Model/ProxyConfidence.cs
+++ b/src/Fingerprint.ServerSdk/Model/ProxyConfidence.cs
@@ -42,7 +42,12 @@ namespace Fingerprint.ServerSdk.Model
         /// <summary>
         /// Enum High for value: high
         /// </summary>
-        High = 3
+        High = 3,
+
+        /// <summary>
+        /// Catch-all value used when the API returns an enum value that this version of the SDK does not recognize. Upgrade the SDK to a version that supports the value.
+        /// </summary>
+        UnsupportedValueSdkUpgradeRequired = -1
     }
 
     /// <summary>
@@ -85,7 +90,7 @@ namespace Fingerprint.ServerSdk.Model
             if (value.Equals("high"))
                 return ProxyConfidence.High;
 
-            return null;
+            return ProxyConfidence.UnsupportedValueSdkUpgradeRequired;
         }
 
         /// <summary>

--- a/src/Fingerprint.ServerSdk/Model/ProxyConfidence.cs
+++ b/src/Fingerprint.ServerSdk/Model/ProxyConfidence.cs
@@ -110,6 +110,9 @@ namespace Fingerprint.ServerSdk.Model
             if (value == ProxyConfidence.High)
                 return "high";
 
+            if (value == ProxyConfidence.UnsupportedValueSdkUpgradeRequired)
+                throw new NotImplementedException("Cannot serialize ProxyConfidence.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }
     }

--- a/src/Fingerprint.ServerSdk/Model/ProxyConfidence.cs
+++ b/src/Fingerprint.ServerSdk/Model/ProxyConfidence.cs
@@ -110,8 +110,11 @@ namespace Fingerprint.ServerSdk.Model
             if (value == ProxyConfidence.High)
                 return "high";
 
+            // Serialize the catch-all value rather than throwing, so models holding an enum value
+            // this SDK version does not support can still be re-serialized. The original (unsupported)
+            // value is not preserved.
             if (value == ProxyConfidence.UnsupportedValueSdkUpgradeRequired)
-                throw new NotImplementedException("Cannot serialize ProxyConfidence.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+                return "unsupported_value_sdk_upgrade_required";
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }

--- a/src/Fingerprint.ServerSdk/Model/ProxyDetails.cs
+++ b/src/Fingerprint.ServerSdk/Model/ProxyDetails.cs
@@ -118,6 +118,9 @@ namespace Fingerprint.ServerSdk.Model
             if (value == ProxyTypeEnum.DataCenter)
                 return "data_center";
 
+            if (value == ProxyTypeEnum.UnsupportedValueSdkUpgradeRequired)
+                throw new NotImplementedException("Cannot serialize ProxyTypeEnum.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }
 

--- a/src/Fingerprint.ServerSdk/Model/ProxyDetails.cs
+++ b/src/Fingerprint.ServerSdk/Model/ProxyDetails.cs
@@ -63,7 +63,12 @@ namespace Fingerprint.ServerSdk.Model
             /// Enum DataCenter for value: data_center
             /// </summary>
 
-            DataCenter = 2
+            DataCenter = 2,
+
+            /// <summary>
+            /// Catch-all value used when the API returns an enum value that this version of the SDK does not recognize. Upgrade the SDK to a version that supports the value.
+            /// </summary>
+            UnsupportedValueSdkUpgradeRequired = -1
         }
 
         /// <summary>
@@ -96,7 +101,7 @@ namespace Fingerprint.ServerSdk.Model
             if (value.Equals("data_center"))
                 return ProxyTypeEnum.DataCenter;
 
-            return null;
+            return ProxyTypeEnum.UnsupportedValueSdkUpgradeRequired;
         }
 
         /// <summary>

--- a/src/Fingerprint.ServerSdk/Model/ProxyDetails.cs
+++ b/src/Fingerprint.ServerSdk/Model/ProxyDetails.cs
@@ -118,8 +118,11 @@ namespace Fingerprint.ServerSdk.Model
             if (value == ProxyTypeEnum.DataCenter)
                 return "data_center";
 
+            // Serialize the catch-all value rather than throwing, so models holding an enum value
+            // this SDK version does not support can still be re-serialized. The original (unsupported)
+            // value is not preserved.
             if (value == ProxyTypeEnum.UnsupportedValueSdkUpgradeRequired)
-                throw new NotImplementedException("Cannot serialize ProxyTypeEnum.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+                return "unsupported_value_sdk_upgrade_required";
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }

--- a/src/Fingerprint.ServerSdk/Model/RareDevicePercentileBucket.cs
+++ b/src/Fingerprint.ServerSdk/Model/RareDevicePercentileBucket.cs
@@ -152,8 +152,11 @@ namespace Fingerprint.ServerSdk.Model
             if (value == RareDevicePercentileBucket.NotSeen)
                 return "not_seen";
 
+            // Serialize the catch-all value rather than throwing, so models holding an enum value
+            // this SDK version does not support can still be re-serialized. The original (unsupported)
+            // value is not preserved.
             if (value == RareDevicePercentileBucket.UnsupportedValueSdkUpgradeRequired)
-                throw new NotImplementedException("Cannot serialize RareDevicePercentileBucket.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+                return "unsupported_value_sdk_upgrade_required";
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }

--- a/src/Fingerprint.ServerSdk/Model/RareDevicePercentileBucket.cs
+++ b/src/Fingerprint.ServerSdk/Model/RareDevicePercentileBucket.cs
@@ -152,6 +152,9 @@ namespace Fingerprint.ServerSdk.Model
             if (value == RareDevicePercentileBucket.NotSeen)
                 return "not_seen";
 
+            if (value == RareDevicePercentileBucket.UnsupportedValueSdkUpgradeRequired)
+                throw new NotImplementedException("Cannot serialize RareDevicePercentileBucket.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }
     }

--- a/src/Fingerprint.ServerSdk/Model/RareDevicePercentileBucket.cs
+++ b/src/Fingerprint.ServerSdk/Model/RareDevicePercentileBucket.cs
@@ -57,7 +57,12 @@ namespace Fingerprint.ServerSdk.Model
         /// <summary>
         /// Enum NotSeen for value: not_seen
         /// </summary>
-        NotSeen = 6
+        NotSeen = 6,
+
+        /// <summary>
+        /// Catch-all value used when the API returns an enum value that this version of the SDK does not recognize. Upgrade the SDK to a version that supports the value.
+        /// </summary>
+        UnsupportedValueSdkUpgradeRequired = -1
     }
 
     /// <summary>
@@ -118,7 +123,7 @@ namespace Fingerprint.ServerSdk.Model
             if (value.Equals("not_seen"))
                 return RareDevicePercentileBucket.NotSeen;
 
-            return null;
+            return RareDevicePercentileBucket.UnsupportedValueSdkUpgradeRequired;
         }
 
         /// <summary>

--- a/src/Fingerprint.ServerSdk/Model/RuleActionType.cs
+++ b/src/Fingerprint.ServerSdk/Model/RuleActionType.cs
@@ -96,6 +96,9 @@ namespace Fingerprint.ServerSdk.Model
             if (value == RuleActionType.Block)
                 return "block";
 
+            if (value == RuleActionType.UnsupportedValueSdkUpgradeRequired)
+                throw new NotImplementedException("Cannot serialize RuleActionType.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }
     }

--- a/src/Fingerprint.ServerSdk/Model/RuleActionType.cs
+++ b/src/Fingerprint.ServerSdk/Model/RuleActionType.cs
@@ -96,8 +96,11 @@ namespace Fingerprint.ServerSdk.Model
             if (value == RuleActionType.Block)
                 return "block";
 
+            // Serialize the catch-all value rather than throwing, so models holding an enum value
+            // this SDK version does not support can still be re-serialized. The original (unsupported)
+            // value is not preserved.
             if (value == RuleActionType.UnsupportedValueSdkUpgradeRequired)
-                throw new NotImplementedException("Cannot serialize RuleActionType.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+                return "unsupported_value_sdk_upgrade_required";
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }

--- a/src/Fingerprint.ServerSdk/Model/RuleActionType.cs
+++ b/src/Fingerprint.ServerSdk/Model/RuleActionType.cs
@@ -37,7 +37,12 @@ namespace Fingerprint.ServerSdk.Model
         /// <summary>
         /// Enum Block for value: block
         /// </summary>
-        Block = 2
+        Block = 2,
+
+        /// <summary>
+        /// Catch-all value used when the API returns an enum value that this version of the SDK does not recognize. Upgrade the SDK to a version that supports the value.
+        /// </summary>
+        UnsupportedValueSdkUpgradeRequired = -1
     }
 
     /// <summary>
@@ -74,7 +79,7 @@ namespace Fingerprint.ServerSdk.Model
             if (value.Equals("block"))
                 return RuleActionType.Block;
 
-            return null;
+            return RuleActionType.UnsupportedValueSdkUpgradeRequired;
         }
 
         /// <summary>

--- a/src/Fingerprint.ServerSdk/Model/SDK.cs
+++ b/src/Fingerprint.ServerSdk/Model/SDK.cs
@@ -148,8 +148,11 @@ namespace Fingerprint.ServerSdk.Model
             if (value == PlatformEnum.Unknown)
                 return "unknown";
 
+            // Serialize the catch-all value rather than throwing, so models holding an enum value
+            // this SDK version does not support can still be re-serialized. The original (unsupported)
+            // value is not preserved.
             if (value == PlatformEnum.UnsupportedValueSdkUpgradeRequired)
-                throw new NotImplementedException("Cannot serialize PlatformEnum.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+                return "unsupported_value_sdk_upgrade_required";
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }

--- a/src/Fingerprint.ServerSdk/Model/SDK.cs
+++ b/src/Fingerprint.ServerSdk/Model/SDK.cs
@@ -75,7 +75,12 @@ namespace Fingerprint.ServerSdk.Model
             /// Enum Unknown for value: unknown
             /// </summary>
 
-            Unknown = 4
+            Unknown = 4,
+
+            /// <summary>
+            /// Catch-all value used when the API returns an enum value that this version of the SDK does not recognize. Upgrade the SDK to a version that supports the value.
+            /// </summary>
+            UnsupportedValueSdkUpgradeRequired = -1
         }
 
         /// <summary>
@@ -120,7 +125,7 @@ namespace Fingerprint.ServerSdk.Model
             if (value.Equals("unknown"))
                 return PlatformEnum.Unknown;
 
-            return null;
+            return PlatformEnum.UnsupportedValueSdkUpgradeRequired;
         }
 
         /// <summary>

--- a/src/Fingerprint.ServerSdk/Model/SDK.cs
+++ b/src/Fingerprint.ServerSdk/Model/SDK.cs
@@ -148,6 +148,9 @@ namespace Fingerprint.ServerSdk.Model
             if (value == PlatformEnum.Unknown)
                 return "unknown";
 
+            if (value == PlatformEnum.UnsupportedValueSdkUpgradeRequired)
+                throw new NotImplementedException("Cannot serialize PlatformEnum.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }
 

--- a/src/Fingerprint.ServerSdk/Model/SearchEventsBot.cs
+++ b/src/Fingerprint.ServerSdk/Model/SearchEventsBot.cs
@@ -47,7 +47,12 @@ namespace Fingerprint.ServerSdk.Model
         /// <summary>
         /// Enum None for value: none
         /// </summary>
-        None = 4
+        None = 4,
+
+        /// <summary>
+        /// Catch-all value used when the API returns an enum value that this version of the SDK does not recognize. Upgrade the SDK to a version that supports the value.
+        /// </summary>
+        UnsupportedValueSdkUpgradeRequired = -1
     }
 
     /// <summary>
@@ -96,7 +101,7 @@ namespace Fingerprint.ServerSdk.Model
             if (value.Equals("none"))
                 return SearchEventsBot.None;
 
-            return null;
+            return SearchEventsBot.UnsupportedValueSdkUpgradeRequired;
         }
 
         /// <summary>

--- a/src/Fingerprint.ServerSdk/Model/SearchEventsBot.cs
+++ b/src/Fingerprint.ServerSdk/Model/SearchEventsBot.cs
@@ -124,6 +124,9 @@ namespace Fingerprint.ServerSdk.Model
             if (value == SearchEventsBot.None)
                 return "none";
 
+            if (value == SearchEventsBot.UnsupportedValueSdkUpgradeRequired)
+                throw new NotImplementedException("Cannot serialize SearchEventsBot.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }
     }

--- a/src/Fingerprint.ServerSdk/Model/SearchEventsBot.cs
+++ b/src/Fingerprint.ServerSdk/Model/SearchEventsBot.cs
@@ -124,8 +124,11 @@ namespace Fingerprint.ServerSdk.Model
             if (value == SearchEventsBot.None)
                 return "none";
 
+            // Serialize the catch-all value rather than throwing, so models holding an enum value
+            // this SDK version does not support can still be re-serialized. The original (unsupported)
+            // value is not preserved.
             if (value == SearchEventsBot.UnsupportedValueSdkUpgradeRequired)
-                throw new NotImplementedException("Cannot serialize SearchEventsBot.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+                return "unsupported_value_sdk_upgrade_required";
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }

--- a/src/Fingerprint.ServerSdk/Model/SearchEventsBotInfo.cs
+++ b/src/Fingerprint.ServerSdk/Model/SearchEventsBotInfo.cs
@@ -37,7 +37,12 @@ namespace Fingerprint.ServerSdk.Model
         /// <summary>
         /// Enum None for value: none
         /// </summary>
-        None = 2
+        None = 2,
+
+        /// <summary>
+        /// Catch-all value used when the API returns an enum value that this version of the SDK does not recognize. Upgrade the SDK to a version that supports the value.
+        /// </summary>
+        UnsupportedValueSdkUpgradeRequired = -1
     }
 
     /// <summary>
@@ -74,7 +79,7 @@ namespace Fingerprint.ServerSdk.Model
             if (value.Equals("none"))
                 return SearchEventsBotInfo.None;
 
-            return null;
+            return SearchEventsBotInfo.UnsupportedValueSdkUpgradeRequired;
         }
 
         /// <summary>

--- a/src/Fingerprint.ServerSdk/Model/SearchEventsBotInfo.cs
+++ b/src/Fingerprint.ServerSdk/Model/SearchEventsBotInfo.cs
@@ -96,8 +96,11 @@ namespace Fingerprint.ServerSdk.Model
             if (value == SearchEventsBotInfo.None)
                 return "none";
 
+            // Serialize the catch-all value rather than throwing, so models holding an enum value
+            // this SDK version does not support can still be re-serialized. The original (unsupported)
+            // value is not preserved.
             if (value == SearchEventsBotInfo.UnsupportedValueSdkUpgradeRequired)
-                throw new NotImplementedException("Cannot serialize SearchEventsBotInfo.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+                return "unsupported_value_sdk_upgrade_required";
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }

--- a/src/Fingerprint.ServerSdk/Model/SearchEventsBotInfo.cs
+++ b/src/Fingerprint.ServerSdk/Model/SearchEventsBotInfo.cs
@@ -96,6 +96,9 @@ namespace Fingerprint.ServerSdk.Model
             if (value == SearchEventsBotInfo.None)
                 return "none";
 
+            if (value == SearchEventsBotInfo.UnsupportedValueSdkUpgradeRequired)
+                throw new NotImplementedException("Cannot serialize SearchEventsBotInfo.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }
     }

--- a/src/Fingerprint.ServerSdk/Model/SearchEventsIncrementalIdentificationStatus.cs
+++ b/src/Fingerprint.ServerSdk/Model/SearchEventsIncrementalIdentificationStatus.cs
@@ -37,7 +37,12 @@ namespace Fingerprint.ServerSdk.Model
         /// <summary>
         /// Enum Completed for value: completed
         /// </summary>
-        Completed = 2
+        Completed = 2,
+
+        /// <summary>
+        /// Catch-all value used when the API returns an enum value that this version of the SDK does not recognize. Upgrade the SDK to a version that supports the value.
+        /// </summary>
+        UnsupportedValueSdkUpgradeRequired = -1
     }
 
     /// <summary>
@@ -74,7 +79,7 @@ namespace Fingerprint.ServerSdk.Model
             if (value.Equals("completed"))
                 return SearchEventsIncrementalIdentificationStatus.Completed;
 
-            return null;
+            return SearchEventsIncrementalIdentificationStatus.UnsupportedValueSdkUpgradeRequired;
         }
 
         /// <summary>

--- a/src/Fingerprint.ServerSdk/Model/SearchEventsIncrementalIdentificationStatus.cs
+++ b/src/Fingerprint.ServerSdk/Model/SearchEventsIncrementalIdentificationStatus.cs
@@ -96,6 +96,9 @@ namespace Fingerprint.ServerSdk.Model
             if (value == SearchEventsIncrementalIdentificationStatus.Completed)
                 return "completed";
 
+            if (value == SearchEventsIncrementalIdentificationStatus.UnsupportedValueSdkUpgradeRequired)
+                throw new NotImplementedException("Cannot serialize SearchEventsIncrementalIdentificationStatus.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }
     }

--- a/src/Fingerprint.ServerSdk/Model/SearchEventsIncrementalIdentificationStatus.cs
+++ b/src/Fingerprint.ServerSdk/Model/SearchEventsIncrementalIdentificationStatus.cs
@@ -96,8 +96,11 @@ namespace Fingerprint.ServerSdk.Model
             if (value == SearchEventsIncrementalIdentificationStatus.Completed)
                 return "completed";
 
+            // Serialize the catch-all value rather than throwing, so models holding an enum value
+            // this SDK version does not support can still be re-serialized. The original (unsupported)
+            // value is not preserved.
             if (value == SearchEventsIncrementalIdentificationStatus.UnsupportedValueSdkUpgradeRequired)
-                throw new NotImplementedException("Cannot serialize SearchEventsIncrementalIdentificationStatus.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+                return "unsupported_value_sdk_upgrade_required";
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }

--- a/src/Fingerprint.ServerSdk/Model/SearchEventsRareDevicePercentileBucket.cs
+++ b/src/Fingerprint.ServerSdk/Model/SearchEventsRareDevicePercentileBucket.cs
@@ -152,8 +152,11 @@ namespace Fingerprint.ServerSdk.Model
             if (value == SearchEventsRareDevicePercentileBucket.NotSeen)
                 return "not_seen";
 
+            // Serialize the catch-all value rather than throwing, so models holding an enum value
+            // this SDK version does not support can still be re-serialized. The original (unsupported)
+            // value is not preserved.
             if (value == SearchEventsRareDevicePercentileBucket.UnsupportedValueSdkUpgradeRequired)
-                throw new NotImplementedException("Cannot serialize SearchEventsRareDevicePercentileBucket.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+                return "unsupported_value_sdk_upgrade_required";
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }

--- a/src/Fingerprint.ServerSdk/Model/SearchEventsRareDevicePercentileBucket.cs
+++ b/src/Fingerprint.ServerSdk/Model/SearchEventsRareDevicePercentileBucket.cs
@@ -152,6 +152,9 @@ namespace Fingerprint.ServerSdk.Model
             if (value == SearchEventsRareDevicePercentileBucket.NotSeen)
                 return "not_seen";
 
+            if (value == SearchEventsRareDevicePercentileBucket.UnsupportedValueSdkUpgradeRequired)
+                throw new NotImplementedException("Cannot serialize SearchEventsRareDevicePercentileBucket.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }
     }

--- a/src/Fingerprint.ServerSdk/Model/SearchEventsRareDevicePercentileBucket.cs
+++ b/src/Fingerprint.ServerSdk/Model/SearchEventsRareDevicePercentileBucket.cs
@@ -57,7 +57,12 @@ namespace Fingerprint.ServerSdk.Model
         /// <summary>
         /// Enum NotSeen for value: not_seen
         /// </summary>
-        NotSeen = 6
+        NotSeen = 6,
+
+        /// <summary>
+        /// Catch-all value used when the API returns an enum value that this version of the SDK does not recognize. Upgrade the SDK to a version that supports the value.
+        /// </summary>
+        UnsupportedValueSdkUpgradeRequired = -1
     }
 
     /// <summary>
@@ -118,7 +123,7 @@ namespace Fingerprint.ServerSdk.Model
             if (value.Equals("not_seen"))
                 return SearchEventsRareDevicePercentileBucket.NotSeen;
 
-            return null;
+            return SearchEventsRareDevicePercentileBucket.UnsupportedValueSdkUpgradeRequired;
         }
 
         /// <summary>

--- a/src/Fingerprint.ServerSdk/Model/SearchEventsSdkPlatform.cs
+++ b/src/Fingerprint.ServerSdk/Model/SearchEventsSdkPlatform.cs
@@ -110,8 +110,11 @@ namespace Fingerprint.ServerSdk.Model
             if (value == SearchEventsSdkPlatform.Ios)
                 return "ios";
 
+            // Serialize the catch-all value rather than throwing, so models holding an enum value
+            // this SDK version does not support can still be re-serialized. The original (unsupported)
+            // value is not preserved.
             if (value == SearchEventsSdkPlatform.UnsupportedValueSdkUpgradeRequired)
-                throw new NotImplementedException("Cannot serialize SearchEventsSdkPlatform.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+                return "unsupported_value_sdk_upgrade_required";
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }

--- a/src/Fingerprint.ServerSdk/Model/SearchEventsSdkPlatform.cs
+++ b/src/Fingerprint.ServerSdk/Model/SearchEventsSdkPlatform.cs
@@ -110,6 +110,9 @@ namespace Fingerprint.ServerSdk.Model
             if (value == SearchEventsSdkPlatform.Ios)
                 return "ios";
 
+            if (value == SearchEventsSdkPlatform.UnsupportedValueSdkUpgradeRequired)
+                throw new NotImplementedException("Cannot serialize SearchEventsSdkPlatform.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }
     }

--- a/src/Fingerprint.ServerSdk/Model/SearchEventsSdkPlatform.cs
+++ b/src/Fingerprint.ServerSdk/Model/SearchEventsSdkPlatform.cs
@@ -42,7 +42,12 @@ namespace Fingerprint.ServerSdk.Model
         /// <summary>
         /// Enum Ios for value: ios
         /// </summary>
-        Ios = 3
+        Ios = 3,
+
+        /// <summary>
+        /// Catch-all value used when the API returns an enum value that this version of the SDK does not recognize. Upgrade the SDK to a version that supports the value.
+        /// </summary>
+        UnsupportedValueSdkUpgradeRequired = -1
     }
 
     /// <summary>
@@ -85,7 +90,7 @@ namespace Fingerprint.ServerSdk.Model
             if (value.Equals("ios"))
                 return SearchEventsSdkPlatform.Ios;
 
-            return null;
+            return SearchEventsSdkPlatform.UnsupportedValueSdkUpgradeRequired;
         }
 
         /// <summary>

--- a/src/Fingerprint.ServerSdk/Model/SearchEventsVpnConfidence.cs
+++ b/src/Fingerprint.ServerSdk/Model/SearchEventsVpnConfidence.cs
@@ -42,7 +42,12 @@ namespace Fingerprint.ServerSdk.Model
         /// <summary>
         /// Enum Low for value: low
         /// </summary>
-        Low = 3
+        Low = 3,
+
+        /// <summary>
+        /// Catch-all value used when the API returns an enum value that this version of the SDK does not recognize. Upgrade the SDK to a version that supports the value.
+        /// </summary>
+        UnsupportedValueSdkUpgradeRequired = -1
     }
 
     /// <summary>
@@ -85,7 +90,7 @@ namespace Fingerprint.ServerSdk.Model
             if (value.Equals("low"))
                 return SearchEventsVpnConfidence.Low;
 
-            return null;
+            return SearchEventsVpnConfidence.UnsupportedValueSdkUpgradeRequired;
         }
 
         /// <summary>

--- a/src/Fingerprint.ServerSdk/Model/SearchEventsVpnConfidence.cs
+++ b/src/Fingerprint.ServerSdk/Model/SearchEventsVpnConfidence.cs
@@ -110,8 +110,11 @@ namespace Fingerprint.ServerSdk.Model
             if (value == SearchEventsVpnConfidence.Low)
                 return "low";
 
+            // Serialize the catch-all value rather than throwing, so models holding an enum value
+            // this SDK version does not support can still be re-serialized. The original (unsupported)
+            // value is not preserved.
             if (value == SearchEventsVpnConfidence.UnsupportedValueSdkUpgradeRequired)
-                throw new NotImplementedException("Cannot serialize SearchEventsVpnConfidence.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+                return "unsupported_value_sdk_upgrade_required";
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }

--- a/src/Fingerprint.ServerSdk/Model/SearchEventsVpnConfidence.cs
+++ b/src/Fingerprint.ServerSdk/Model/SearchEventsVpnConfidence.cs
@@ -110,6 +110,9 @@ namespace Fingerprint.ServerSdk.Model
             if (value == SearchEventsVpnConfidence.Low)
                 return "low";
 
+            if (value == SearchEventsVpnConfidence.UnsupportedValueSdkUpgradeRequired)
+                throw new NotImplementedException("Cannot serialize SearchEventsVpnConfidence.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }
     }

--- a/src/Fingerprint.ServerSdk/Model/TamperingConfidence.cs
+++ b/src/Fingerprint.ServerSdk/Model/TamperingConfidence.cs
@@ -110,6 +110,9 @@ namespace Fingerprint.ServerSdk.Model
             if (value == TamperingConfidence.High)
                 return "high";
 
+            if (value == TamperingConfidence.UnsupportedValueSdkUpgradeRequired)
+                throw new NotImplementedException("Cannot serialize TamperingConfidence.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }
     }

--- a/src/Fingerprint.ServerSdk/Model/TamperingConfidence.cs
+++ b/src/Fingerprint.ServerSdk/Model/TamperingConfidence.cs
@@ -42,7 +42,12 @@ namespace Fingerprint.ServerSdk.Model
         /// <summary>
         /// Enum High for value: high
         /// </summary>
-        High = 3
+        High = 3,
+
+        /// <summary>
+        /// Catch-all value used when the API returns an enum value that this version of the SDK does not recognize. Upgrade the SDK to a version that supports the value.
+        /// </summary>
+        UnsupportedValueSdkUpgradeRequired = -1
     }
 
     /// <summary>
@@ -85,7 +90,7 @@ namespace Fingerprint.ServerSdk.Model
             if (value.Equals("high"))
                 return TamperingConfidence.High;
 
-            return null;
+            return TamperingConfidence.UnsupportedValueSdkUpgradeRequired;
         }
 
         /// <summary>

--- a/src/Fingerprint.ServerSdk/Model/TamperingConfidence.cs
+++ b/src/Fingerprint.ServerSdk/Model/TamperingConfidence.cs
@@ -110,8 +110,11 @@ namespace Fingerprint.ServerSdk.Model
             if (value == TamperingConfidence.High)
                 return "high";
 
+            // Serialize the catch-all value rather than throwing, so models holding an enum value
+            // this SDK version does not support can still be re-serialized. The original (unsupported)
+            // value is not preserved.
             if (value == TamperingConfidence.UnsupportedValueSdkUpgradeRequired)
-                throw new NotImplementedException("Cannot serialize TamperingConfidence.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+                return "unsupported_value_sdk_upgrade_required";
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }

--- a/src/Fingerprint.ServerSdk/Model/VpnConfidence.cs
+++ b/src/Fingerprint.ServerSdk/Model/VpnConfidence.cs
@@ -42,7 +42,12 @@ namespace Fingerprint.ServerSdk.Model
         /// <summary>
         /// Enum High for value: high
         /// </summary>
-        High = 3
+        High = 3,
+
+        /// <summary>
+        /// Catch-all value used when the API returns an enum value that this version of the SDK does not recognize. Upgrade the SDK to a version that supports the value.
+        /// </summary>
+        UnsupportedValueSdkUpgradeRequired = -1
     }
 
     /// <summary>
@@ -85,7 +90,7 @@ namespace Fingerprint.ServerSdk.Model
             if (value.Equals("high"))
                 return VpnConfidence.High;
 
-            return null;
+            return VpnConfidence.UnsupportedValueSdkUpgradeRequired;
         }
 
         /// <summary>

--- a/src/Fingerprint.ServerSdk/Model/VpnConfidence.cs
+++ b/src/Fingerprint.ServerSdk/Model/VpnConfidence.cs
@@ -110,8 +110,11 @@ namespace Fingerprint.ServerSdk.Model
             if (value == VpnConfidence.High)
                 return "high";
 
+            // Serialize the catch-all value rather than throwing, so models holding an enum value
+            // this SDK version does not support can still be re-serialized. The original (unsupported)
+            // value is not preserved.
             if (value == VpnConfidence.UnsupportedValueSdkUpgradeRequired)
-                throw new NotImplementedException("Cannot serialize VpnConfidence.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+                return "unsupported_value_sdk_upgrade_required";
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }

--- a/src/Fingerprint.ServerSdk/Model/VpnConfidence.cs
+++ b/src/Fingerprint.ServerSdk/Model/VpnConfidence.cs
@@ -110,6 +110,9 @@ namespace Fingerprint.ServerSdk.Model
             if (value == VpnConfidence.High)
                 return "high";
 
+            if (value == VpnConfidence.UnsupportedValueSdkUpgradeRequired)
+                throw new NotImplementedException("Cannot serialize VpnConfidence.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }
     }

--- a/template/modelEnum.mustache
+++ b/template/modelEnum.mustache
@@ -34,12 +34,19 @@
         [EnumMember(Value = "{{{value}}}")]
         {{/useGenericHost}}
         {{/isString}}
-        {{name}}{{^isString}} = {{{value}}}{{/isString}}{{#isString}}{{^vendorExtensions.x-zero-based-enum}} = {{-index}}{{/vendorExtensions.x-zero-based-enum}}{{/isString}}{{^-last}},{{/-last}}
+        {{name}}{{^isString}} = {{{value}}}{{/isString}}{{#isString}}{{^vendorExtensions.x-zero-based-enum}} = {{-index}}{{/vendorExtensions.x-zero-based-enum}}{{/isString}}{{^-last}},{{/-last}}{{#-last}}{{#isString}},{{/isString}}{{/-last}}
         {{^-last}}
 
         {{/-last}}
         {{/enumVars}}
         {{/allowableValues}}
+        {{#isString}}
+
+        /// <summary>
+        /// Catch-all value used when the API returns an enum value that this version of the SDK does not recognize. Upgrade the SDK to a version that supports the value.
+        /// </summary>
+        UnsupportedValueSdkUpgradeRequired = -1
+        {{/isString}}
     }
     {{#useGenericHost}}
 
@@ -79,7 +86,12 @@
 
             {{/enumVars}}
             {{/allowableValues}}
+            {{#isString}}
+            return {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}.UnsupportedValueSdkUpgradeRequired;
+            {{/isString}}
+            {{^isString}}
             return null;
+            {{/isString}}
         }
 
         /// <summary>

--- a/template/modelEnum.mustache
+++ b/template/modelEnum.mustache
@@ -113,8 +113,11 @@
 
             {{/enumVars}}
             {{/allowableValues}}
+            // Serialize the catch-all value rather than throwing, so models holding an enum value
+            // this SDK version does not support can still be re-serialized. The original (unsupported)
+            // value is not preserved.
             if (value == {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}.UnsupportedValueSdkUpgradeRequired)
-                throw new NotImplementedException("Cannot serialize {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+                return "unsupported_value_sdk_upgrade_required";
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
             {{/isString}}

--- a/template/modelEnum.mustache
+++ b/template/modelEnum.mustache
@@ -113,6 +113,9 @@
 
             {{/enumVars}}
             {{/allowableValues}}
+            if (value == {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}.UnsupportedValueSdkUpgradeRequired)
+                throw new NotImplementedException("Cannot serialize {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+
             throw new NotImplementedException($"Value could not be handled: '{value}'");
             {{/isString}}
         }

--- a/template/modelInnerEnum.mustache
+++ b/template/modelInnerEnum.mustache
@@ -105,8 +105,11 @@
 
             {{/enumVars}}
             {{/allowableValues}}
+            // Serialize the catch-all value rather than throwing, so models holding an enum value
+            // this SDK version does not support can still be re-serialized. The original (unsupported)
+            // value is not preserved.
             if (value == {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}.UnsupportedValueSdkUpgradeRequired)
-                throw new NotImplementedException("Cannot serialize {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+                return "unsupported_value_sdk_upgrade_required";
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
             {{/isString}}

--- a/template/modelInnerEnum.mustache
+++ b/template/modelInnerEnum.mustache
@@ -105,6 +105,9 @@
 
             {{/enumVars}}
             {{/allowableValues}}
+            if (value == {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}.UnsupportedValueSdkUpgradeRequired)
+                throw new NotImplementedException("Cannot serialize {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}.UnsupportedValueSdkUpgradeRequired: it represents an enum value returned by the API that this version of the SDK does not support. Upgrade the SDK to a version that supports the value.");
+
             throw new NotImplementedException($"Value could not be handled: '{value}'");
             {{/isString}}
         }

--- a/template/modelInnerEnum.mustache
+++ b/template/modelInnerEnum.mustache
@@ -23,12 +23,19 @@
             [EnumMember(Value = "{{{value}}}")]
             {{/isString}}
             {{/useGenericHost}}
-            {{name}}{{^isString}} = {{{value}}}{{/isString}}{{#isString}}{{^vendorExtensions.x-zero-based-enum}} = {{-index}}{{/vendorExtensions.x-zero-based-enum}}{{/isString}}{{^-last}},{{/-last}}
+            {{name}}{{^isString}} = {{{value}}}{{/isString}}{{#isString}}{{^vendorExtensions.x-zero-based-enum}} = {{-index}}{{/vendorExtensions.x-zero-based-enum}}{{/isString}}{{^-last}},{{/-last}}{{#-last}}{{#isString}},{{/isString}}{{/-last}}
             {{^-last}}
 
             {{/-last}}
             {{/enumVars}}
             {{/allowableValues}}
+            {{#isString}}
+
+            /// <summary>
+            /// Catch-all value used when the API returns an enum value that this version of the SDK does not recognize. Upgrade the SDK to a version that supports the value.
+            /// </summary>
+            UnsupportedValueSdkUpgradeRequired = -1
+            {{/isString}}
         }
         {{#useGenericHost}}
 
@@ -64,7 +71,12 @@
 
             {{/enumVars}}
             {{/allowableValues}}
+            {{#isString}}
+            return {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}.UnsupportedValueSdkUpgradeRequired;
+            {{/isString}}
+            {{^isString}}
             return null;
+            {{/isString}}
         }
 
         /// <summary>


### PR DESCRIPTION
When the server API adds a new value to a string enum (e.g. `proxy_details.proxy_type = "unknown"`, added in SMSI-1887), the .NET SDK failed to deserialize the event. Adding an enum value is backward-compatible per OAS, but the generated deserializer rejected unknown values. Because `proxy_type` is a **required** field, mapping the unknown value to `null` was not an option. That would violate the `required` constraint and still throw.

Resolves #178.

## Changes

- Following the Java SDK's approach, every generated string enum now has a catch-all member `UnsupportedValueSdkUpgradeRequired`. Unrecognized values deserialize to this member instead of throwing, preserving the rest of the event.
- The fix is in the OpenAPI Generator templates (`template/modelInnerEnum.mustache`, `template/modelEnum.mustache`): `FromStringOrDefault` returns the catch-all instead of `null`.
- Serializing a model that holds the catch-all throws a clear, actionable `NotImplementedException` (the original raw value is intentionally not preserved, so round-tripping is not supported)..