### PR TITLE
[INTER-2060] .NET Care

### DIFF
--- a/.changeset/bump-dependencies.md
+++ b/.changeset/bump-dependencies.md
@@ -1,5 +1,5 @@
 ---
-'fingerprint-server-dotnet-sdk': patch
+'fingerprint-server-dotnet-sdk': minor
 ---
 
 Update dependencies: bump `Microsoft.Extensions.Http`/`Microsoft.Extensions.Hosting` to 8.0.1 and `Microsoft.Extensions.Http.Polly` to 8.0.8. This raises the minimum transitive dependency floor (including `System.Text.Json` 8.0.5) for `netstandard2.0` and `net48` consumers.

--- a/.changeset/bump-dependencies.md
+++ b/.changeset/bump-dependencies.md
@@ -2,4 +2,4 @@
 'fingerprint-server-dotnet-sdk': patch
 ---
 
-Update dependencies: bump `Microsoft.Extensions.Http`/`Microsoft.Extensions.Hosting` to 8.0.1 and `Microsoft.Extensions.Http.Polly` to 8.0.8.
+Update dependencies: bump `Microsoft.Extensions.Http`/`Microsoft.Extensions.Hosting` to 8.0.1 and `Microsoft.Extensions.Http.Polly` to 8.0.8. This raises the minimum transitive dependency floor (including `System.Text.Json` 8.0.5) for `netstandard2.0` and `net48` consumers.

--- a/.changeset/bump-dependencies.md
+++ b/.changeset/bump-dependencies.md
@@ -1,0 +1,5 @@
+---
+'fingerprint-server-dotnet-sdk': patch
+---
+
+Update dependencies: bump `Microsoft.Extensions.Http`/`Microsoft.Extensions.Hosting` to 8.0.1 and `Microsoft.Extensions.Http.Polly` to 8.0.8 (still compatible with all supported target frameworks: net8.0, netstandard2.0, netstandard2.1, net48). Align and update the test toolchain (`Microsoft.NET.Test.Sdk` 18.8.1, `xunit` 2.9.3, `xunit.runner.visualstudio` 3.1.5) across the test projects.

--- a/.changeset/bump-dependencies.md
+++ b/.changeset/bump-dependencies.md
@@ -2,4 +2,4 @@
 'fingerprint-server-dotnet-sdk': patch
 ---
 
-Update dependencies: bump `Microsoft.Extensions.Http`/`Microsoft.Extensions.Hosting` to 8.0.1 and `Microsoft.Extensions.Http.Polly` to 8.0.8 (still compatible with all supported target frameworks: net8.0, netstandard2.0, netstandard2.1, net48). Align and update the test toolchain (`Microsoft.NET.Test.Sdk` 18.8.1, `xunit` 2.9.3, `xunit.runner.visualstudio` 3.1.5) across the test projects.
+Update dependencies: bump `Microsoft.Extensions.Http`/`Microsoft.Extensions.Hosting` to 8.0.1 and `Microsoft.Extensions.Http.Polly` to 8.0.8.

--- a/.changeset/webhook-deserialization-docs.md
+++ b/.changeset/webhook-deserialization-docs.md
@@ -1,0 +1,5 @@
+---
+'fingerprint-server-dotnet-sdk': patch
+---
+
+Document how to deserialize an incoming webhook payload into the built-in `Event` model using the SDK's configured `JsonSerializerOptions`, alongside the existing webhook signature validation guidance.

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -10,7 +10,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Read version from config.json
         id: version
         run: echo version=$(node -p "require('./config.json').packageVersion") >> $GITHUB_OUTPUT

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       
       # Get a short-lived NuGet API key
       - name: NuGet login (OIDC → temp API key)
-        uses: NuGet/login@v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 #v1.2.0
         id: login
         with:
           user: ${{ secrets.NUGET_USER }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,10 @@ jobs:
       id-token: write  # enable GitHub OIDC token issuance for this job
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: 'Install DotNET'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 8.x
       

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,9 +27,9 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ public class WebhookController : ControllerBase
     [HttpPost]
     public async Task<IActionResult> Post()
     {
+        // Validate webhook signature first before deserializing (see "Webhook signature validation" section)
         using var reader = new StreamReader(Request.Body);
         var body = await reader.ReadToEndAsync();
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ public static IHostBuilder CreateHostBuilder(string[] args) => Host.CreateDefaul
 
 ## Sealed results
 
-This SDK provides utility methods for decoding [sealed results](https://dev.fingerprint.com/docs/sealed-client-results).
+This SDK provides utility methods for decoding [sealed results](https://docs.fingerprint.com/docs/sealed-client-results).
 ```csharp
 using Fingerprint.ServerSdk;
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,50 @@ var event = Sealed.UnsealEventResponse(Convert.FromBase64String(sealedResult), n
 
 To learn more, refer to example located in [src/Fingerprint.ServerSdk.SealedResultExample/Program.cs](src/Fingerprint.ServerSdk.SealedResultExample/Program.cs).
 
-## Webhook signature validation
+## Webhooks
+
+### Deserializing the webhook payload
+
+When handling [webhooks](https://docs.fingerprint.com/reference/webhook) coming from Fingerprint, you can deserialize the request body into the built-in `Event` model. The `JsonSerializerOptionsProvider` registered by `ConfigureFingerprint` carries all the SDK's model converters, so inject it and reuse its `Options`:
+
+```csharp
+namespace FingerprintAspNetCore.Areas.Identity.Pages;
+
+using Fingerprint.ServerSdk.Client;
+using Fingerprint.ServerSdk.Model;
+using Microsoft.AspNetCore.Mvc;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+[Route("api/[controller]")]
+[ApiController]
+public class WebhookController : ControllerBase
+{
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    public WebhookController(JsonSerializerOptionsProvider jsonSerializerOptionsProvider)
+    {
+        _jsonOptions = jsonSerializerOptionsProvider.Options;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Post()
+    {
+        using var reader = new StreamReader(Request.Body);
+        var body = await reader.ReadToEndAsync();
+
+        var webhookEvent = JsonSerializer.Deserialize<Event>(body, _jsonOptions);
+
+        // Access strongly-typed identification and Smart Signals data, e.g.:
+        var visitorId = webhookEvent?.Identification?.VisitorId;
+
+        return Ok(new { message = "Webhook received." });
+    }
+}
+```
+
+### Webhook signature validation
 
 This SDK provides utility method for verifying the HMAC signature of the incoming webhook request.
 

--- a/docs/models/WebhookValidation.md
+++ b/docs/models/WebhookValidation.md
@@ -6,7 +6,7 @@
 
 Verifies the HMAC signature extracted from the "fpjs-event-signature" header of the incoming request. This is a part of
 the webhook signing process.
-You can enable and configure webhook signatures from your Fingerprint dashboard. To learn more, please refer to our support: https://fingerprint.com/support
+You can enable and configure webhook signatures from your Fingerprint dashboard. To learn more, see https://fingerprint.com/support
 
 ### Required Parameters
 

--- a/docs/models/WebhookValidation.md
+++ b/docs/models/WebhookValidation.md
@@ -5,8 +5,8 @@
 > bool IsValidSignature(string header, byte[] data, string secret)
 
 Verifies the HMAC signature extracted from the "fpjs-event-signature" header of the incoming request. This is a part of
-the webhook signing process, which is available only for enterprise customers.
-If you wish to enable it, please contact our support: https://fingerprint.com/support
+the webhook signing process.
+You can enable and configure webhook signatures from your Fingerprint dashboard. To learn more, please refer to our support: https://fingerprint.com/support
 
 ### Required Parameters
 

--- a/src/Fingerprint.ServerSdk.FunctionalTest/Fingerprint.ServerSdk.FunctionalTest.csproj
+++ b/src/Fingerprint.ServerSdk.FunctionalTest/Fingerprint.ServerSdk.FunctionalTest.csproj
@@ -11,9 +11,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Fingerprint.ServerSdk.Test/Fingerprint.ServerSdk.Test.csproj
+++ b/src/Fingerprint.ServerSdk.Test/Fingerprint.ServerSdk.Test.csproj
@@ -10,9 +10,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Fingerprint.ServerSdk/Fingerprint.ServerSdk.csproj
+++ b/src/Fingerprint.ServerSdk/Fingerprint.ServerSdk.csproj
@@ -27,9 +27,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="5.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
         <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     </ItemGroup>

--- a/src/Fingerprint.ServerSdk/WebhookValidation.cs
+++ b/src/Fingerprint.ServerSdk/WebhookValidation.cs
@@ -16,8 +16,8 @@ public static class WebhookValidation
     }
 
     /// <summary>
-    /// Verifies the HMAC signature extracted from the "fpjs-event-signature" header of the incoming request. This is a part of the webhook signing process, which is available only for enterprise customers.
-    /// If you wish to enable it, please contact our support: https://fingerprint.com/support
+    /// Verifies the HMAC signature extracted from the "fpjs-event-signature" header of the incoming request. This is a part of the webhook signing process.
+    /// You can enable and configure webhook signatures from your Fingerprint dashboard. To learn more, please refer to our support: https://fingerprint.com/support
     /// </summary>
     ///
     /// <param name="header">The value of the "fpjs-event-signature" header.</param>

--- a/src/Fingerprint.ServerSdk/WebhookValidation.cs
+++ b/src/Fingerprint.ServerSdk/WebhookValidation.cs
@@ -17,7 +17,7 @@ public static class WebhookValidation
 
     /// <summary>
     /// Verifies the HMAC signature extracted from the "fpjs-event-signature" header of the incoming request. This is a part of the webhook signing process.
-    /// You can enable and configure webhook signatures from your Fingerprint dashboard. To learn more, please refer to our support: https://fingerprint.com/support
+    /// You can enable and configure webhook signatures from your Fingerprint dashboard. To learn more, see https://fingerprint.com/support.
     /// </summary>
     ///
     /// <param name="header">The value of the "fpjs-event-signature" header.</param>

--- a/template/README.solution.mustache
+++ b/template/README.solution.mustache
@@ -198,7 +198,50 @@ var event = Sealed.UnsealEventResponse(Convert.FromBase64String(sealedResult), n
 
 To learn more, refer to example located in [src/{{packageName}}.SealedResultExample/Program.cs](src/{{packageName}}.SealedResultExample/Program.cs).
 
-## Webhook signature validation
+## Webhooks
+
+### Deserializing the webhook payload
+
+When handling [webhooks](https://docs.fingerprint.com/reference/webhook) coming from Fingerprint, you can deserialize the request body into the built-in `Event` model. The `JsonSerializerOptionsProvider` registered by `ConfigureFingerprint` carries all the SDK's model converters, so inject it and reuse its `Options`:
+
+```csharp
+namespace FingerprintAspNetCore.Areas.Identity.Pages;
+
+using {{packageName}}.Client;
+using {{packageName}}.Model;
+using Microsoft.AspNetCore.Mvc;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+[Route("api/[controller]")]
+[ApiController]
+public class WebhookController : ControllerBase
+{
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    public WebhookController(JsonSerializerOptionsProvider jsonSerializerOptionsProvider)
+    {
+        _jsonOptions = jsonSerializerOptionsProvider.Options;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Post()
+    {
+        using var reader = new StreamReader(Request.Body);
+        var body = await reader.ReadToEndAsync();
+
+        var webhookEvent = JsonSerializer.Deserialize<Event>(body, _jsonOptions);
+
+        // Access strongly-typed identification and Smart Signals data, e.g.:
+        var visitorId = webhookEvent?.Identification?.VisitorId;
+
+        return Ok(new { message = "Webhook received." });
+    }
+}
+```
+
+### Webhook signature validation
 
 This SDK provides utility method for verifying the HMAC signature of the incoming webhook request.
 

--- a/template/README.solution.mustache
+++ b/template/README.solution.mustache
@@ -228,6 +228,7 @@ public class WebhookController : ControllerBase
     [HttpPost]
     public async Task<IActionResult> Post()
     {
+        // Validate webhook signature first before deserializing (see "Webhook signature validation" section)
         using var reader = new StreamReader(Request.Body);
         var body = await reader.ReadToEndAsync();
 

--- a/template/README.solution.mustache
+++ b/template/README.solution.mustache
@@ -183,7 +183,7 @@ public static IHostBuilder CreateHostBuilder(string[] args) => Host.CreateDefaul
 
 ## Sealed results
 
-This SDK provides utility methods for decoding [sealed results](https://dev.fingerprint.com/docs/sealed-client-results).
+This SDK provides utility methods for decoding [sealed results](https://docs.fingerprint.com/docs/sealed-client-results).
 ```csharp
 using {{packageName}};
 

--- a/template/WebhookValidation.md.mustache
+++ b/template/WebhookValidation.md.mustache
@@ -6,7 +6,7 @@
 
 Verifies the HMAC signature extracted from the "fpjs-event-signature" header of the incoming request. This is a part of
 the webhook signing process.
-You can enable and configure webhook signatures from your Fingerprint dashboard. To learn more, please refer to our support: https://fingerprint.com/support
+You can enable and configure webhook signatures from your Fingerprint dashboard. To learn more, see https://fingerprint.com/support
 
 ### Required Parameters
 

--- a/template/WebhookValidation.md.mustache
+++ b/template/WebhookValidation.md.mustache
@@ -5,8 +5,8 @@
 > bool IsValidSignature(string header, byte[] data, string secret)
 
 Verifies the HMAC signature extracted from the "fpjs-event-signature" header of the incoming request. This is a part of
-the webhook signing process, which is available only for enterprise customers.
-If you wish to enable it, please contact our support: https://fingerprint.com/support
+the webhook signing process.
+You can enable and configure webhook signatures from your Fingerprint dashboard. To learn more, please refer to our support: https://fingerprint.com/support
 
 ### Required Parameters
 

--- a/template/WebhookValidation.mustache
+++ b/template/WebhookValidation.mustache
@@ -16,8 +16,8 @@ public static class WebhookValidation
     }
 
     /// <summary>
-    /// Verifies the HMAC signature extracted from the "fpjs-event-signature" header of the incoming request. This is a part of the webhook signing process, which is available only for enterprise customers.
-    /// If you wish to enable it, please contact our support: https://fingerprint.com/support
+    /// Verifies the HMAC signature extracted from the "fpjs-event-signature" header of the incoming request. This is a part of the webhook signing process.
+    /// You can enable and configure webhook signatures from your Fingerprint dashboard. To learn more, please refer to our support: https://fingerprint.com/support
     /// </summary>
     ///
     /// <param name="header">The value of the "fpjs-event-signature" header.</param>

--- a/template/WebhookValidation.mustache
+++ b/template/WebhookValidation.mustache
@@ -17,7 +17,7 @@ public static class WebhookValidation
 
     /// <summary>
     /// Verifies the HMAC signature extracted from the "fpjs-event-signature" header of the incoming request. This is a part of the webhook signing process.
-    /// You can enable and configure webhook signatures from your Fingerprint dashboard. To learn more, please refer to our support: https://fingerprint.com/support
+    /// You can enable and configure webhook signatures from your Fingerprint dashboard. To learn more, see https://fingerprint.com/support.
     /// </summary>
     ///
     /// <param name="header">The value of the "fpjs-event-signature" header.</param>

--- a/template/netcore_project.mustache
+++ b/template/netcore_project.mustache
@@ -40,10 +40,10 @@
         <PackageReference Include="RestSharp" Version="112.0.0" />
         {{/useRestSharp}}
         {{#useGenericHost}}
-        <PackageReference Include="Microsoft.Extensions.Http" Version="{{#lambda.first}}{{#netStandard}}5.0.0  {{/netStandard}}{{#net47}}7.0.0  {{/net47}}{{#net48}}7.0.0  {{/net48}}{{#net6.0}}6.0.0  {{/net6.0}}{{#net7.0}}7.0.0  {{/net7.0}}{{#net8.0}}8.0.1  {{/net8.0}}{{#net9.0}}9.0.5  {{/net9.0}}{{#net10.0}}10.0.1 {{/net10.0}}{{/lambda.first}}" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="{{#lambda.first}}{{#netStandard}}5.0.0  {{/netStandard}}{{#net47}}7.0.0  {{/net47}}{{#net48}}7.0.0  {{/net48}}{{#net6.0}}6.0.1  {{/net6.0}}{{#net7.0}}7.0.1  {{/net7.0}}{{#net8.0}}8.0.1  {{/net8.0}}{{#net9.0}}9.0.5  {{/net9.0}}{{#net10.0}}10.0.1 {{/net10.0}}{{/lambda.first}}" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="{{#lambda.first}}{{#netStandard}}8.0.1  {{/netStandard}}{{#net47}}7.0.0  {{/net47}}{{#net48}}7.0.0  {{/net48}}{{#net6.0}}6.0.0  {{/net6.0}}{{#net7.0}}7.0.0  {{/net7.0}}{{#net8.0}}8.0.1  {{/net8.0}}{{#net9.0}}9.0.5  {{/net9.0}}{{#net10.0}}10.0.1 {{/net10.0}}{{/lambda.first}}" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="{{#lambda.first}}{{#netStandard}}8.0.1  {{/netStandard}}{{#net47}}7.0.0  {{/net47}}{{#net48}}7.0.0  {{/net48}}{{#net6.0}}6.0.1  {{/net6.0}}{{#net7.0}}7.0.1  {{/net7.0}}{{#net8.0}}8.0.1  {{/net8.0}}{{#net9.0}}9.0.5  {{/net9.0}}{{#net10.0}}10.0.1 {{/net10.0}}{{/lambda.first}}" />
         {{#supportsRetry}}
-        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="{{#lambda.first}}{{#netStandard}}5.0.1  {{/netStandard}}{{#net47}}7.0.0  {{/net47}}{{#net48}}7.0.0  {{/net48}}{{#net6.0}}6.0.19  {{/net6.0}}{{#net7.0}}7.0.11  {{/net7.0}}{{#net8.0}}8.0.8  {{/net8.0}}{{#net9.0}}9.0.5  {{/net9.0}}{{#net10.0}}10.0.1 {{/net10.0}}{{/lambda.first}}" />
+        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="{{#lambda.first}}{{#netStandard}}8.0.8  {{/netStandard}}{{#net47}}7.0.0  {{/net47}}{{#net48}}7.0.0  {{/net48}}{{#net6.0}}6.0.19  {{/net6.0}}{{#net7.0}}7.0.11  {{/net7.0}}{{#net8.0}}8.0.8  {{/net8.0}}{{#net9.0}}9.0.5  {{/net9.0}}{{#net10.0}}10.0.1 {{/net10.0}}{{/lambda.first}}" />
         {{/supportsRetry}}
         {{#net80OrLater}}
         <PackageReference Include="Microsoft.Net.Http.Headers" Version="{{#lambda.first}}{{#net8.0}}8.0.8  {{/net8.0}}{{#net9.0}}9.0.5  {{/net9.0}}{{#net10.0}}10.0.1 {{/net10.0}}{{/lambda.first}}" />

--- a/template/netcore_testproject.mustache
+++ b/template/netcore_testproject.mustache
@@ -11,9 +11,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="{{^netStandard}}18.0.1{{/netStandard}}{{#netStandard}}15.9.2{{/netStandard}}" />
-        <PackageReference Include="xunit" Version="{{^netStandard}}2.9.3{{/netStandard}}{{#netStandard}}2.4.2{{/netStandard}}" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="{{^netStandard}}{{#lambda.first}}{{#net80OrLater}}3.1.5  {{/net80OrLater}}{{#net60OrLater}}2.8.2  {{/net60OrLater}}{{#net48OrLater}}3.1.0  {{/net48OrLater}}2.8.2  {{/lambda.first}}{{/netStandard}}{{#netStandard}}2.4.5{{/netStandard}}" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="{{^netStandard}}18.8.1{{/netStandard}}{{#netStandard}}18.8.1{{/netStandard}}" />
+        <PackageReference Include="xunit" Version="{{^netStandard}}2.9.3{{/netStandard}}{{#netStandard}}2.9.3{{/netStandard}}" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="{{^netStandard}}{{#lambda.first}}{{#net80OrLater}}3.1.5  {{/net80OrLater}}{{#net60OrLater}}2.8.2  {{/net60OrLater}}{{#net48OrLater}}3.1.0  {{/net48OrLater}}2.8.2  {{/lambda.first}}{{/netStandard}}{{#netStandard}}3.1.5{{/netStandard}}" />
     </ItemGroup>
 
     <ItemGroup>

--- a/template/netcore_testproject.mustache
+++ b/template/netcore_testproject.mustache
@@ -11,8 +11,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="{{^netStandard}}18.8.1{{/netStandard}}{{#netStandard}}18.8.1{{/netStandard}}" />
-        <PackageReference Include="xunit" Version="{{^netStandard}}2.9.3{{/netStandard}}{{#netStandard}}2.9.3{{/netStandard}}" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+        <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="{{^netStandard}}{{#lambda.first}}{{#net80OrLater}}3.1.5  {{/net80OrLater}}{{#net60OrLater}}2.8.2  {{/net60OrLater}}{{#net48OrLater}}3.1.0  {{/net48OrLater}}2.8.2  {{/lambda.first}}{{/netStandard}}{{#netStandard}}3.1.5{{/netStandard}}" />
     </ItemGroup>
 


### PR DESCRIPTION
# Ecosystem care: dependency updates, docs, 

## Changes

### Dependency updates
- Bumped `Microsoft.Extensions.Http` and `Microsoft.Extensions.Hosting` `5.0.0 → 8.0.1`, and `Microsoft.Extensions.Http.Polly` `5.0.1 → 8.0.8` (edited in `template/netcore_project.mustache`). The 8.0.x line still ships `net462` + `netstandard2.0` assemblies, so all four target frameworks continue to restore and build.
- Aligned and bumped the test toolchain to a single current version across both test projects: `Microsoft.NET.Test.Sdk → 18.8.1` (was 15.9.2 in the generated test project and 17.10.0 in FunctionalTest), `xunit 2.4.2 → 2.9.3`, `xunit.runner.visualstudio 2.4.5 → 3.1.5`.
- `BouncyCastle.Cryptography` (2.6.2) and `System.ComponentModel.Annotations` (5.0.0) were already at their latest published versions, so no change here.

### README: webhook payload deserialization
- Added a "Deserializing the webhook payload" section to the README showing how to deserialize an incoming webhook body into the built-in `Event` model using the DI-registered `JsonSerializerOptionsProvider.Options` (which carries all the SDK's converters).

### Documentation fixes
- Replaced `dev.fingerprint.com` with `docs.fingerprint.com`
- Reworded the webhook signature-validation docs (`WebhookValidation.cs` XML comment + its model doc) to drop the "available only for enterprise customers" restriction

### CI/CD
- Bumped `actions/checkout@v4 → @v7` (`tests.yml`, `publish.yml`, `e2e-tests.yml`) and `actions/setup-dotnet@v4 → @v6` (`tests.yml`, `publish.yml`). `NuGet/login@v1` and the `dx-team-toolkit@v1` reusable workflows were left unchanged.