### PR TITLE
ci: dummy change to trigger release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-
 jobs:
   release:
     name: 'Release project'


### PR DESCRIPTION
Dummy change to re-run release pipeline, as it is failing with a random git error. 

Related run: https://github.com/fingerprintjs/dotnet-sdk/actions/runs/29840837289/job/88901656239